### PR TITLE
On Google Cloud http.DefaultClient is not available

### DIFF
--- a/plaid/plaid.go
+++ b/plaid/plaid.go
@@ -15,6 +15,12 @@ func NewClient(clientID, secret string, environment environmentURL) *Client {
 	return &Client{clientID, secret, environment, &http.Client{}}
 }
 
+// Same as above but with additional parameter to pass http.Client. This is required
+// if you want to run the code on Google AppEngine which prohibits use of http.DefaultClient
+func NewCustomClient(clientID, secret string, environment environmentURL, httpClient *http.Client) *Client {
+	return &Client{clientID, secret, environment, httpClient}
+}
+
 // Note: Client is only exported for method documentation purposes.
 // Instances should only be created through the 'NewClient' function.
 //


### PR DESCRIPTION
On Google Cloud http.DefaultClient is not available, so we need to pass an alternative implementation when creating new Plaid client.

I know NewClientEx is not the best name. Maybe you can come up with a better one or solve this issue in a different way altogether.