### PR TITLE
Change environemntURL type to plain ol' string

### DIFF
--- a/plaid/categories.go
+++ b/plaid/categories.go
@@ -2,14 +2,14 @@ package plaid
 
 // GetCategories returns information for all categories.
 // See https://plaid.com/docs/api/#category-overview.
-func GetCategories(environment environmentURL) (categories []category, err error) {
+func GetCategories(environment string) (categories []category, err error) {
 	err = getAndUnmarshal(environment, "/categories", &categories)
 	return
 }
 
 // GetCategory returns information for a single category given an ID.
 // See https://plaid.com/docs/api/#categories-by-id.
-func GetCategory(environment environmentURL, id string) (cat category, err error) {
+func GetCategory(environment, id string) (cat category, err error) {
 	err = getAndUnmarshal(environment, "/categories/"+id, &cat)
 	return
 }

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -2,14 +2,14 @@ package plaid
 
 // GetInstitution returns information for a single institution given an ID.
 // See https://plaid.com/docs/api/#institutions-by-id.
-func GetInstitution(environment environmentURL, id string) (inst institution, err error) {
+func GetInstitution(environment, id string) (inst institution, err error) {
 	err = getAndUnmarshal(environment, "/institutions/"+id, &inst)
 	return
 }
 
 // GetInstitution returns information for all institutions.
 // See https://plaid.com/docs/api/#all-institutions.
-func GetInstitutions(environment environmentURL) (institutions []institution, err error) {
+func GetInstitutions(environment string) (institutions []institution, err error) {
 	err = getAndUnmarshal(environment, "/institutions", &institutions)
 	return
 }

--- a/plaid/plaid.go
+++ b/plaid/plaid.go
@@ -11,13 +11,13 @@ import (
 
 // NewClient instantiates a Client associated with a client id, secret and environment.
 // See https://plaid.com/docs/api/#gaining-access.
-func NewClient(clientID, secret string, environment environmentURL) *Client {
+func NewClient(clientID, secret string, environment string) *Client {
 	return &Client{clientID, secret, environment, &http.Client{}}
 }
 
 // Same as above but with additional parameter to pass http.Client. This is required
 // if you want to run the code on Google AppEngine which prohibits use of http.DefaultClient
-func NewCustomClient(clientID, secret string, environment environmentURL, httpClient *http.Client) *Client {
+func NewCustomClient(clientID, secret string, environment string, httpClient *http.Client) *Client {
 	return &Client{clientID, secret, environment, httpClient}
 }
 
@@ -28,14 +28,12 @@ func NewCustomClient(clientID, secret string, environment environmentURL, httpCl
 type Client struct {
 	clientID    string
 	secret      string
-	environment environmentURL
+	environment string
 	httpClient  *http.Client
 }
 
-type environmentURL string
-
-var Tartan environmentURL = "https://tartan.plaid.com"
-var Production environmentURL = "https://api.plaid.com"
+var Tartan string = "https://tartan.plaid.com"
+var Production string = "https://api.plaid.com"
 
 type Account struct {
 	ID      string `json:"_id"`
@@ -149,7 +147,7 @@ type deleteResponse struct {
 }
 
 // getAndUnmarshal is not a method because no client authentication is required
-func getAndUnmarshal(environment environmentURL, endpoint string, structure interface{}) error {
+func getAndUnmarshal(environment, endpoint string, structure interface{}) error {
 	res, err := http.Get(string(environment) + endpoint)
 	if err != nil {
 		return err


### PR DESCRIPTION
When using environmental variables, we can't pass in the URL if the type is unexported. It's better to just use plain ol' strings.
