### PR TITLE
Export all return types

### DIFF
--- a/plaid/auth.go
+++ b/plaid/auth.go
@@ -9,7 +9,7 @@ import (
 //
 // See https://plaid.com/docs/api/#add-auth-user.
 func (c *Client) AuthAddUser(username, password, pin, institutionType string,
-	options *AuthOptions) (postRes *postResponse, mfaRes *mfaResponse, err error) {
+	options *AuthOptions) (postRes *PostResponse, mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(authJson{
 		c.clientID,
@@ -30,8 +30,8 @@ func (c *Client) AuthAddUser(username, password, pin, institutionType string,
 // e.g. `{"mask":"xxx-xxx-5309"}`.
 //
 // See https://plaid.com/docs/api/#auth-mfa.
-func (c *Client) AuthStepSendMethod(accessToken, key, value string) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) AuthStepSendMethod(accessToken, key, value string) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	sendMethod := map[string]string{key: value}
 	jsonText, err := json.Marshal(authStepSendMethodJson{
@@ -49,8 +49,8 @@ func (c *Client) AuthStepSendMethod(accessToken, key, value string) (postRes *po
 // AuthStep (POST /auth/step) submits an MFA answer for a given access token.
 //
 // See https://plaid.com/docs/api/#auth-mfa.
-func (c *Client) AuthStep(accessToken, answer string) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) AuthStep(accessToken, answer string) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(authStepJson{
 		c.clientID,
@@ -67,7 +67,7 @@ func (c *Client) AuthStep(accessToken, answer string) (postRes *postResponse,
 // AuthGet (POST /auth/get) retrieves account data for a given access token.
 //
 // See https://plaid.com/docs/api/#get-auth-data.
-func (c *Client) AuthGet(accessToken string) (postRes *postResponse, err error) {
+func (c *Client) AuthGet(accessToken string) (postRes *PostResponse, err error) {
 	jsonText, err := json.Marshal(authGetJson{
 		c.clientID,
 		c.secret,
@@ -84,8 +84,8 @@ func (c *Client) AuthGet(accessToken string) (postRes *postResponse, err error) 
 // AuthUpdate (PATCH /auth) updates user credentials for a given access token.
 //
 // See https://plaid.com/docs/api/#update-auth-user.
-func (c *Client) AuthUpdate(username, password, pin, accessToken string) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) AuthUpdate(username, password, pin, accessToken string) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(authUpdateJson{
 		c.clientID,
@@ -104,8 +104,8 @@ func (c *Client) AuthUpdate(username, password, pin, accessToken string) (postRe
 // AuthUpdateStep (PATCH /auth/step) updates user credentials and MFA for a given access token.
 //
 // See https://plaid.com/docs/api/#update-auth-user.
-func (c *Client) AuthUpdateStep(username, password, pin, mfa, accessToken string) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) AuthUpdateStep(username, password, pin, mfa, accessToken string) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(authUpdateStepJson{
 		c.clientID,
@@ -125,7 +125,7 @@ func (c *Client) AuthUpdateStep(username, password, pin, mfa, accessToken string
 // AuthDelete (DELETE /auth) deletes data for a given access token.
 //
 // See https://plaid.com/docs/api/#delete-auth-user.
-func (c *Client) AuthDelete(accessToken string) (deleteRes *deleteResponse, err error) {
+func (c *Client) AuthDelete(accessToken string) (deleteRes *DeleteResponse, err error) {
 	jsonText, err := json.Marshal(authDeleteJson{
 		c.clientID,
 		c.secret,

--- a/plaid/balance.go
+++ b/plaid/balance.go
@@ -8,7 +8,7 @@ import (
 // Balance (POST /balance) retrieves real-time balance for a given access token.
 //
 // See https://plaid.com/docs/api/#balance.
-func (c *Client) Balance(accessToken string) (postRes *postResponse, err error) {
+func (c *Client) Balance(accessToken string) (postRes *PostResponse, err error) {
 	jsonText, err := json.Marshal(balanceJson{
 		c.clientID,
 		c.secret,

--- a/plaid/connect.go
+++ b/plaid/connect.go
@@ -9,7 +9,7 @@ import (
 //
 // See https://plaid.com/docs/api/#add-user.
 func (c *Client) ConnectAddUser(username, password, pin, institutionType string,
-	options *ConnectOptions) (postRes *postResponse, mfaRes *mfaResponse, err error) {
+	options *ConnectOptions) (postRes *PostResponse, mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(connectJson{
 		c.clientID,
@@ -30,8 +30,8 @@ func (c *Client) ConnectAddUser(username, password, pin, institutionType string,
 // e.g. `{"mask":"xxx-xxx-5309"}`.
 //
 // See https://plaid.com/docs/api/#mfa-authentication.
-func (c *Client) ConnectStepSendMethod(accessToken, key, value string) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) ConnectStepSendMethod(accessToken, key, value string) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	sendMethod := map[string]string{key: value}
 	jsonText, err := json.Marshal(connectStepSendMethodJson{
@@ -49,8 +49,8 @@ func (c *Client) ConnectStepSendMethod(accessToken, key, value string) (postRes 
 // ConnectStep (POST /connect/step) submits an MFA answer for a given access token.
 //
 // See https://plaid.com/docs/api/#mfa-authentication.
-func (c *Client) ConnectStep(accessToken, answer string) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) ConnectStep(accessToken, answer string) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(connectStepJson{
 		c.clientID,
@@ -67,8 +67,8 @@ func (c *Client) ConnectStep(accessToken, answer string) (postRes *postResponse,
 // ConnectGet (POST /connect/get) retrieves account and transaction data for a given access token.
 //
 // See https://plaid.com/docs/api/#get-transactions.
-func (c *Client) ConnectGet(accessToken string, options *ConnectGetOptions) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) ConnectGet(accessToken string, options *ConnectGetOptions) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(connectGetJson{
 		c.clientID,
@@ -85,8 +85,8 @@ func (c *Client) ConnectGet(accessToken string, options *ConnectGetOptions) (pos
 // ConnectUpdate (PATCH /connect) updates user credentials for a given access token.
 //
 // See https://plaid.com/docs/api/#update-user.
-func (c *Client) ConnectUpdate(username, password, pin, accessToken string) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) ConnectUpdate(username, password, pin, accessToken string) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(connectUpdateJson{
 		c.clientID,
@@ -105,8 +105,8 @@ func (c *Client) ConnectUpdate(username, password, pin, accessToken string) (pos
 // ConnectUpdateStep (PATCH /connect/step) updates user credentials and MFA for a given access token.
 //
 // See https://plaid.com/docs/api/#update-user.
-func (c *Client) ConnectUpdateStep(username, password, pin, mfa, accessToken string) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) ConnectUpdateStep(username, password, pin, mfa, accessToken string) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(connectUpdateStepJson{
 		c.clientID,
@@ -126,7 +126,7 @@ func (c *Client) ConnectUpdateStep(username, password, pin, mfa, accessToken str
 // ConnectDelete (DELETE /connect) deletes data for a given access token.
 //
 // See https://plaid.com/docs/api/#delete-user.
-func (c *Client) ConnectDelete(accessToken string) (deleteRes *deleteResponse, err error) {
+func (c *Client) ConnectDelete(accessToken string) (deleteRes *DeleteResponse, err error) {
 	jsonText, err := json.Marshal(connectDeleteJson{
 		c.clientID,
 		c.secret,

--- a/plaid/exchange-token.go
+++ b/plaid/exchange-token.go
@@ -8,7 +8,7 @@ import (
 // ExchangeToken (POST /exchange_token) exchanges a public token for an access token.
 //
 // See https://github.com/plaid/link
-func (c *Client) ExchangeToken(publicToken string) (postRes *postResponse, err error) {
+func (c *Client) ExchangeToken(publicToken string) (postRes *PostResponse, err error) {
 	jsonText, err := json.Marshal(exchangeJson{
 		c.clientID,
 		c.secret,
@@ -23,7 +23,7 @@ func (c *Client) ExchangeToken(publicToken string) (postRes *postResponse, err e
 
 // ExchangeTokenAccount (POST /exchange_token) exchanges a public token and account id to receive a
 // bank account token.
-func (c *Client) ExchangeTokenAccount(publicToken string, accountId string) (postRes *postResponse, err error) {
+func (c *Client) ExchangeTokenAccount(publicToken string, accountId string) (postRes *PostResponse, err error) {
 	jsonText, err := json.Marshal(exchangeAccountJson{
 		c.clientID,
 		c.secret,

--- a/plaid/plaid.go
+++ b/plaid/plaid.go
@@ -102,39 +102,39 @@ type Transaction struct {
 	} `json:"score"`
 }
 
-type mfaIntermediate struct {
+type MFAIntermediate struct {
 	AccessToken string      `json:"access_token"`
 	MFA         interface{} `json:"mfa"`
 	Type        string      `json:"type"`
 }
-type mfaDevice struct {
-	Message string
+type MFADevice struct {
+	Message string `json:"message"`
 }
-type mfaList struct {
+type MFAList struct {
 	Mask string
 	Type string
 }
-type mfaQuestion struct {
+type MFAQuestion struct {
 	Question string
 }
-type mfaSelection struct {
+type MFASelection struct {
 	Answers  []string
 	Question string
 }
 
 // 'mfa' contains the union of all possible mfa types
 // Users should switch on the 'Type' field
-type mfaResponse struct {
+type MFAResponse struct {
 	AccessToken string
 	Type        string
 
-	Device     mfaDevice
-	List       []mfaList
-	Questions  []mfaQuestion
-	Selections []mfaSelection
+	Device     MFADevice
+	List       []MFAList
+	Questions  []MFAQuestion
+	Selections []MFASelection
 }
 
-type postResponse struct {
+type PostResponse struct {
 	// Normal response fields
 	AccessToken      string        `json:"access_token"`
 	AccountId        string        `json:"account_id"`
@@ -144,7 +144,7 @@ type postResponse struct {
 	Transactions     []Transaction `json:"transactions"`
 }
 
-type deleteResponse struct {
+type DeleteResponse struct {
 	Message string `json:"message"`
 }
 
@@ -177,7 +177,7 @@ func getAndUnmarshal(environment environmentURL, endpoint string, structure inte
 }
 
 func (c *Client) postAndUnmarshal(endpoint string,
-	body io.Reader) (*postResponse, *mfaResponse, error) {
+	body io.Reader) (*PostResponse, *MFAResponse, error) {
 	// Read response body
 	req, err := http.NewRequest("POST", string(c.environment)+endpoint, body)
 	if err != nil {
@@ -199,7 +199,7 @@ func (c *Client) postAndUnmarshal(endpoint string,
 }
 
 func (c *Client) patchAndUnmarshal(endpoint string,
-	body io.Reader) (*postResponse, *mfaResponse, error) {
+	body io.Reader) (*PostResponse, *MFAResponse, error) {
 
 	req, err := http.NewRequest("PATCH", string(c.environment)+endpoint, body)
 	if err != nil {
@@ -221,7 +221,7 @@ func (c *Client) patchAndUnmarshal(endpoint string,
 }
 
 func (c *Client) deleteAndUnmarshal(endpoint string,
-	body io.Reader) (*deleteResponse, error) {
+	body io.Reader) (*DeleteResponse, error) {
 
 	req, err := http.NewRequest("DELETE", string(c.environment)+endpoint, body)
 	if err != nil {
@@ -240,7 +240,7 @@ func (c *Client) deleteAndUnmarshal(endpoint string,
 	res.Body.Close()
 
 	// Successful response
-	var deleteRes deleteResponse
+	var deleteRes DeleteResponse
 	if res.StatusCode == 200 {
 		if err = json.Unmarshal(raw, &deleteRes); err != nil {
 			return nil, err
@@ -256,11 +256,11 @@ func (c *Client) deleteAndUnmarshal(endpoint string,
 	return nil, plaidErr
 }
 
-// Unmarshals response into postResponse, mfaResponse, or plaidError
-func unmarshalPostMFA(res *http.Response, body []byte) (*postResponse, *mfaResponse, error) {
+// Unmarshals response into PostResponse, MFAResponse, or plaidError
+func unmarshalPostMFA(res *http.Response, body []byte) (*PostResponse, *MFAResponse, error) {
 	// Different marshaling cases
-	var mfaInter mfaIntermediate
-	var postRes postResponse
+	var mfaInter MFAIntermediate
+	var postRes PostResponse
 	var err error
 	switch {
 	// Successful response
@@ -275,7 +275,7 @@ func unmarshalPostMFA(res *http.Response, body []byte) (*postResponse, *mfaRespo
 		if err = json.Unmarshal(body, &mfaInter); err != nil {
 			return nil, nil, err
 		}
-		mfaRes := mfaResponse{Type: mfaInter.Type, AccessToken: mfaInter.AccessToken}
+		mfaRes := MFAResponse{Type: mfaInter.Type, AccessToken: mfaInter.AccessToken}
 		switch mfaInter.Type {
 		case "device":
 			temp, ok := mfaInter.MFA.(interface{})
@@ -310,7 +310,7 @@ func unmarshalPostMFA(res *http.Response, body []byte) (*postResponse, *mfaRespo
 				if !ok {
 					return nil, nil, errors.New("Could not decode list mfa")
 				}
-				mfaRes.List = append(mfaRes.List, mfaList{maskText, typeText})
+				mfaRes.List = append(mfaRes.List, MFAList{maskText, typeText})
 			}
 
 		case "questions":
@@ -327,7 +327,7 @@ func unmarshalPostMFA(res *http.Response, body []byte) (*postResponse, *mfaRespo
 				if !ok {
 					return nil, nil, errors.New("Could not decode questions mfa question")
 				}
-				mfaRes.Questions = append(mfaRes.Questions, mfaQuestion{questionText})
+				mfaRes.Questions = append(mfaRes.Questions, MFAQuestion{questionText})
 			}
 
 		case "selections":
@@ -355,7 +355,7 @@ func unmarshalPostMFA(res *http.Response, body []byte) (*postResponse, *mfaRespo
 				if !ok {
 					return nil, nil, errors.New("Could not decode selections questions")
 				}
-				mfaRes.Selections = append(mfaRes.Selections, mfaSelection{answers, question})
+				mfaRes.Selections = append(mfaRes.Selections, MFASelection{answers, question})
 			}
 		}
 		return nil, &mfaRes, nil

--- a/plaid/upgrade.go
+++ b/plaid/upgrade.go
@@ -9,7 +9,7 @@ import (
 //
 // See https://plaid.com/docs/api/#upgrade-user.
 func (c *Client) Upgrade(accessToken, upgradeTo string,
-	options *UpgradeOptions) (postRes *postResponse, mfaRes *mfaResponse, err error) {
+	options *UpgradeOptions) (postRes *PostResponse, mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(upgradeJson{
 		c.clientID,
@@ -28,8 +28,8 @@ func (c *Client) Upgrade(accessToken, upgradeTo string,
 // e.g. {"mask":"xxx-xxx-5309"}.
 //
 // See https://plaid.com/docs/api/#upgrade-user.
-func (c *Client) UpgradeStepSendMethod(accessToken, key, value string) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) UpgradeStepSendMethod(accessToken, key, value string) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	sendMethod := map[string]string{key: value}
 	jsonText, err := json.Marshal(upgradeStepSendMethodJson{
@@ -48,8 +48,8 @@ func (c *Client) UpgradeStepSendMethod(accessToken, key, value string) (postRes 
 //
 // See https://plaid.com/docs/api/#mfa-authentication for upgrades to Connect.
 // See https://plaid.com/docs/api/#mfa-auth for upgrades to Auth.
-func (c *Client) UpgradeStep(accessToken, answer string) (postRes *postResponse,
-	mfaRes *mfaResponse, err error) {
+func (c *Client) UpgradeStep(accessToken, answer string) (postRes *PostResponse,
+	mfaRes *MFAResponse, err error) {
 
 	jsonText, err := json.Marshal(upgradeStepJson{
 		c.clientID,


### PR DESCRIPTION
Simple change to address https://github.com/plaid/plaid-go/issues/28. Rename only. 

I expect this change to be fully backwards compatible, since these symbols are not referenced in any existing client code.