### PR TITLE
Update institutions endpoints

### DIFF
--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -12,17 +12,21 @@ import (
 // GetInstitution returns information for a single institution given an ID.
 // See: https://plaid.com/docs/api/#institutions-by-id
 func GetInstitution(environment environmentURL, id string) (inst institution, err error) {
+	if id == "" {
+		return inst, errors.New("/institutions/all/:id - institution id must be specified")
+	}
+
 	err = getAndUnmarshal(environment, "/institutions/all/"+id, &inst)
-	return
+	return inst, err
 }
 
 // GetInstitutionsSearch returns all institutions that match the query parameters.
 // If product parameter is included, results are filtered by product.
 // If institution id option is specified, query and product parameters are ignored.
 // See: https://plaid.com/docs/api/#institution-search
-func GetInstitutionsSearch(environment environmentURL, query, product, id string) (institutions []institutionJson, err error) {
+func GetInstitutionsSearch(environment environmentURL, query, product, id string) (institutions []institutionExtended, err error) {
 	if query == "" && id == "" {
-		return nil, errors.New("Query or institution id must be specified")
+		return nil, errors.New("/institutions/all/ - query or institution id must be specified")
 	}
 
 	v := url.Values{}
@@ -30,11 +34,9 @@ func GetInstitutionsSearch(environment environmentURL, query, product, id string
 	if query != "" {
 		v.Add("q", query)
 	}
-
 	if product != "" {
 		v.Add("p", product)
 	}
-
 	if id != "" {
 		v.Add("id", id)
 	}
@@ -44,6 +46,7 @@ func GetInstitutionsSearch(environment environmentURL, query, product, id string
 }
 
 // Returns all financial institutions currently supported by Plaid.
+// If not specified, count defaults to 50.
 // See: https://plaid.com/docs/api/#all-institutions
 func (c *Client) GetInstitutions(environment environmentURL, products []string, count int, offset int) (institutions []institution, err error) {
 	// Default to count=50.
@@ -114,7 +117,7 @@ type institutionsJson struct {
 	Offset   int      `json:"offset"`
 }
 
-type institutionJson struct {
+type institutionExtended struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`
 	Products struct {

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -15,7 +15,7 @@ func TestInstitutions(t *testing.T) {
 
 var _ = Describe("institutions", func() {
 
-	Describe("GetInstitutions", func() {
+	Describe("GetInstitutionsSearch", func() {
 
 		It("returns non-empty array", func() {
 			institutions, err := GetInstitutionsSearch(Tartan, "redwood", "auth", "ins_100042")
@@ -52,6 +52,24 @@ var _ = Describe("institutions", func() {
 			Expect(i.Products).To(ContainElement("connect"))
 		})
 
+	})
+
+	Describe("GetInstitutions", func() {
+		It("returns non-empty array", func() {
+			c := NewClient("test_id", "test_secret", Tartan)
+			institutions, err := c.GetInstitutions(Tartan, []string{"connect", "auth"}, 20, 0)
+			Expect(err).To(BeNil(), "err should be nil")
+			Expect(institutions).ToNot(BeEmpty())
+		})
+	})
+
+	Describe("GetInstitutions", func() {
+		It("returns non-empty array", func() {
+			c := NewClient("test_id", "test_secret", Tartan)
+			institutions, err := c.GetInstitutions(Tartan, []string{}, 0, 0)
+			Expect(err).To(BeNil(), "err should be nil")
+			Expect(institutions).ToNot(BeEmpty())
+		})
 	})
 
 })

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -29,9 +29,10 @@ var _ = Describe("institutions", func() {
 			Expect(institutions).ToNot(BeEmpty())
 		})
 
-		It("returns a query or institution must be specified error", func() {
+		It("returns an error", func() {
 			institutions, err := GetInstitutionsSearch(Tartan, "", "connect", "")
 			Expect(err).ToNot(BeNil(), "err should not be nil")
+			Expect(err.Error()).To(Equal("/institutions/all/ - query or institution id must be specified"))
 			Expect(institutions).To(BeEmpty())
 		})
 
@@ -50,6 +51,16 @@ var _ = Describe("institutions", func() {
 			Expect(i.Products).ToNot(BeEmpty())
 			Expect(i.Products).To(ContainElement("balance"))
 			Expect(i.Products).To(ContainElement("connect"))
+		})
+
+	})
+
+	Describe("GetInstitution", func() {
+
+		It("returns an error", func() {
+			_, err := GetInstitution(Tartan, "") // id not specified.
+			Expect(err).ToNot(BeNil(), "err should not be nil")
+			Expect(err.Error()).To(Equal("/institutions/all/:id - institution id must be specified"))
 		})
 
 	})

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -18,9 +18,21 @@ var _ = Describe("institutions", func() {
 	Describe("GetInstitutions", func() {
 
 		It("returns non-empty array", func() {
-			institutions, err := GetInstitutions(Tartan)
+			institutions, err := GetInstitutionsSearch(Tartan, "redwood", "auth", "ins_100042")
 			Expect(err).To(BeNil(), "err should be nil")
 			Expect(institutions).ToNot(BeEmpty())
+		})
+
+		It("returns non-empty array", func() {
+			institutions, err := GetInstitutionsSearch(Tartan, "chase", "connect", "")
+			Expect(err).To(BeNil(), "err should be nil")
+			Expect(institutions).ToNot(BeEmpty())
+		})
+
+		It("returns a query or institution must be specified error", func() {
+			institutions, err := GetInstitutionsSearch(Tartan, "", "connect", "")
+			Expect(err).ToNot(BeNil(), "err should not be nil")
+			Expect(institutions).To(BeEmpty())
 		})
 
 	})

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -58,7 +58,7 @@ var _ = Describe("institutions", func() {
 	Describe("GetInstitution", func() {
 
 		It("returns an error", func() {
-			_, err := GetInstitution(Tartan, "") // id not specified.
+			_, err := GetInstitution(Tartan, "")
 			Expect(err).ToNot(BeNil(), "err should not be nil")
 			Expect(err.Error()).To(Equal("/institutions/all/:id - institution id must be specified"))
 		})


### PR DESCRIPTION
Addresses https://github.com/plaid/plaid-go/issues/33.  Old `/institutions` endpoints are replaced by new ones:

- `/institutions/all`
- `/institutions/all/:id`
- `/institutions/all/search`