### PR TITLE
Fix: `GetInstitutions` no longer package function

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,8 +9,11 @@ import (
 
 // main contains example usage of all functions
 func main() {
+	// Create a Plaid client
+	client := plaid.NewClient("test_id", "test_secret", plaid.Tartan)
+
 	// GET /institutions
-	res, err := plaid.GetInstitutions(plaid.Tartan)
+	res, err := client.GetInstitutions(plaid.Tartan, nil, 50, 0)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -36,8 +39,6 @@ func main() {
 		fmt.Println(err)
 	}
 	fmt.Println("category", category.ID, "is", strings.Join(category.Hierarchy, ", "))
-
-	client := plaid.NewClient("test_id", "test_secret", plaid.Tartan)
 
 	// POST /auth
 	postRes, mfaRes, err :=


### PR DESCRIPTION
Previous, `GetInstitution` used to be a package function. That has
changed since https://github.com/plaid/plaid-go/commit/a61bc9dd11501e3d190f25f39c6a3cbe4eb61a36).
This PR updates main.go accordingly.