### PR TITLE
Use transaction ranges in tests that have transactions

### DIFF
--- a/plaid/investment_transactions_test.go
+++ b/plaid/investment_transactions_test.go
@@ -10,8 +10,8 @@ import (
 func TestGetInvestmentTransactions(t *testing.T) {
 	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, []string{"investments"})
 	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	startDateString := "2018-06-01"
-	endDateString := "2019-06-01"
+	startDateString := time.Now().Add(-365 * 24 * time.Hour).Format(iso8601TimeFormat)
+	endDateString := time.Now().Format(iso8601TimeFormat)
 	investmentTransactionsResp, err := testClient.GetInvestmentTransactions(tokenResp.AccessToken, startDateString, endDateString)
 
 	if plaidErr, ok := err.(Error); ok {

--- a/plaid/transactions_test.go
+++ b/plaid/transactions_test.go
@@ -7,15 +7,19 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
+const iso8601TimeFormat = "2006-01-02"
+
 func TestGetTransactions(t *testing.T) {
 	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
 	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	transactionsResp, err := testClient.GetTransactions(tokenResp.AccessToken, "2016-01-01", "2017-01-01")
+	startDate := time.Now().Add(-365 * 24 * time.Hour).Format(iso8601TimeFormat)
+	endDate := time.Now().Format(iso8601TimeFormat)
+	transactionsResp, err := testClient.GetTransactions(tokenResp.AccessToken, startDate, endDate)
 
 	if plaidErr, ok := err.(Error); ok {
 		for ok && plaidErr.ErrorCode == "PRODUCT_NOT_READY" {
 			time.Sleep(5 * time.Second)
-			transactionsResp, err = testClient.GetTransactions(tokenResp.AccessToken, "2016-01-01", "2017-01-01")
+			transactionsResp, err = testClient.GetTransactions(tokenResp.AccessToken, startDate, endDate)
 			plaidErr, ok = err.(Error)
 		}
 	}
@@ -29,9 +33,11 @@ func TestGetTransactionsWithOptions(t *testing.T) {
 	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
 	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
 
+	startDate := time.Now().Add(-365 * 24 * time.Hour).Format(iso8601TimeFormat)
+	endDate := time.Now().Format(iso8601TimeFormat)
 	options := GetTransactionsOptions{
-		StartDate:  "2016-01-01",
-		EndDate:    "2017-01-01",
+		StartDate:  startDate,
+		EndDate:    endDate,
 		AccountIDs: []string{},
 		Count:      2,
 		Offset:     1,


### PR DESCRIPTION
Sandbox items will not always return transactions for the dates that we've previously written into the tests. This change makes the tests less brittle.