### PR TITLE
Include Item in GetAccountsResponse

### DIFF
--- a/plaid/accounts.go
+++ b/plaid/accounts.go
@@ -80,6 +80,7 @@ type getAccountsRequest struct {
 type GetAccountsResponse struct {
 	APIResponse
 	Accounts []Account `json:"accounts"`
+	Item Item `json:"item"`
 }
 
 type GetAccountsOptions struct {


### PR DESCRIPTION
Item is the only object that contains errors in the returned response from the request. To be able to handle errors from a response the Item object is needed.