### PR TITLE
Add support for Ocrolus processor tokens

### DIFF
--- a/plaid/processor.go
+++ b/plaid/processor.go
@@ -29,6 +29,18 @@ type CreateDwollaTokenResponse struct {
 	ProcessorToken string `json:"processor_token"`
 }
 
+type createOcrolusTokenRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+	AccountID   string `json:"account_id"`
+}
+
+type CreateOcrolusTokenResponse struct {
+	APIResponse
+	ProcessorToken string `json:"processor_token"`
+}
+
 type createStripeTokenRequest struct {
 	ClientID    string `json:"client_id"`
 	Secret      string `json:"secret"`
@@ -77,6 +89,26 @@ func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp CreateDw
 	}
 
 	err = c.Call("/processor/dwolla/processor_token/create", jsonBody, &resp)
+	return resp, err
+
+}
+
+func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp CreateOcrolusTokenResponse, err error) {
+	if accessToken == "" || accountID == "" {
+		return resp, errors.New("/processor/ocrolus/processor_token/create - access token and account ID must be specified")
+	}
+
+	jsonBody, err := json.Marshal(createOcrolusTokenRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+		AccountID:   accountID,
+	})
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/processor/ocrolus/processor_token/create", jsonBody, &resp)
 	return resp, err
 
 }

--- a/plaid/processor.go
+++ b/plaid/processor.go
@@ -12,10 +12,14 @@ type createProcessorTokenRequest struct {
 	AccountID   string `json:"account_id"`
 }
 
-type CreateProcessorTokenResponse struct {
+type createProcessorTokenResponse struct {
 	APIResponse
 	ProcessorToken string `json:"processor_token"`
 }
+
+type CreateApexTokenResponse createProcessorTokenResponse
+type CreateDwollaTokenResponse createProcessorTokenResponse
+type CreateOcrolusTokenResponse createProcessorTokenResponse
 
 type createStripeTokenRequest struct {
 	ClientID    string `json:"client_id"`
@@ -29,8 +33,7 @@ type CreateStripeTokenResponse struct {
 	StripeBankAccountToken string `json:"stripe_bank_account_token"`
 }
 
-// CreateProcessorToken is a helper function used to create processor tokens for a given api endpoint.
-func (c *Client) CreateProcessorToken(apiEndpoint, accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
+func (c *Client) createProcessorToken(apiEndpoint, accessToken, accountID string) (resp createProcessorTokenResponse, err error) {
 	if accessToken == "" || accountID == "" {
 		return resp, errors.New(apiEndpoint + " - access token and account ID must be specified")
 	}
@@ -50,18 +53,21 @@ func (c *Client) CreateProcessorToken(apiEndpoint, accessToken, accountID string
 }
 
 // CreateApexToken is used to create a new Apex processor token.
-func (c *Client) CreateApexToken(accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
-	return c.CreateProcessorToken("/processor/apex/processor_token/create", accessToken, accountID)
+func (c *Client) CreateApexToken(accessToken, accountID string) (resp CreateApexTokenResponse, err error) {
+	response, err := c.createProcessorToken("/processor/apex/processor_token/create", accessToken, accountID)
+	return CreateApexTokenResponse(response), err
 }
 
 // CreateDwollaToken is used to create a new Dwolla processor token.
-func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
-	return c.CreateProcessorToken("/processor/dwolla/processor_token/create", accessToken, accountID)
+func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp CreateDwollaTokenResponse, err error) {
+	response, err := c.createProcessorToken("/processor/dwolla/processor_token/create", accessToken, accountID)
+	return CreateDwollaTokenResponse(response), err
 }
 
 // CreateOcrolusToken is used to create a new Ocrolus processor token.
-func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
-	return c.CreateProcessorToken("/processor/ocrolus/processor_token/create", accessToken, accountID)
+func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp CreateOcrolusTokenResponse, err error) {
+	response, err := c.createProcessorToken("/processor/ocrolus/processor_token/create", accessToken, accountID)
+	return CreateOcrolusTokenResponse(response), err
 }
 
 // CreateStripeToken is used to create a new Stripe bank account token.

--- a/plaid/processor.go
+++ b/plaid/processor.go
@@ -5,38 +5,14 @@ import (
 	"errors"
 )
 
-type createApexTokenRequest struct {
+type createProcessorTokenRequest struct {
 	ClientID    string `json:"client_id"`
 	Secret      string `json:"secret"`
 	AccessToken string `json:"access_token"`
 	AccountID   string `json:"account_id"`
 }
 
-type CreateApexTokenResponse struct {
-	APIResponse
-	ProcessorToken string `json:"processor_token"`
-}
-
-type createDwollaTokenRequest struct {
-	ClientID    string `json:"client_id"`
-	Secret      string `json:"secret"`
-	AccessToken string `json:"access_token"`
-	AccountID   string `json:"account_id"`
-}
-
-type CreateDwollaTokenResponse struct {
-	APIResponse
-	ProcessorToken string `json:"processor_token"`
-}
-
-type createOcrolusTokenRequest struct {
-	ClientID    string `json:"client_id"`
-	Secret      string `json:"secret"`
-	AccessToken string `json:"access_token"`
-	AccountID   string `json:"account_id"`
-}
-
-type CreateOcrolusTokenResponse struct {
+type CreateProcessorTokenResponse struct {
 	APIResponse
 	ProcessorToken string `json:"processor_token"`
 }
@@ -53,12 +29,13 @@ type CreateStripeTokenResponse struct {
 	StripeBankAccountToken string `json:"stripe_bank_account_token"`
 }
 
-func (c *Client) CreateApexToken(accessToken, accountID string) (resp CreateApexTokenResponse, err error) {
+// CreateProcessorToken is a helper function used to create processor tokens for a given api endpoint.
+func (c *Client) CreateProcessorToken(apiEndpoint, accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
 	if accessToken == "" || accountID == "" {
-		return resp, errors.New("/processor/apex/processor_token/create - access token and account ID must be specified")
+		return resp, errors.New(apiEndpoint + " - access token and account ID must be specified")
 	}
 
-	jsonBody, err := json.Marshal(createApexTokenRequest{
+	jsonBody, err := json.Marshal(createProcessorTokenRequest{
 		ClientID:    c.clientID,
 		Secret:      c.secret,
 		AccessToken: accessToken,
@@ -68,51 +45,26 @@ func (c *Client) CreateApexToken(accessToken, accountID string) (resp CreateApex
 		return resp, err
 	}
 
-	err = c.Call("/processor/apex/processor_token/create", jsonBody, &resp)
+	err = c.Call(apiEndpoint, jsonBody, &resp)
 	return resp, err
-
 }
 
-func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp CreateDwollaTokenResponse, err error) {
-	if accessToken == "" || accountID == "" {
-		return resp, errors.New("/processor/dwolla/processor_token/create - access token and account ID must be specified")
-	}
-
-	jsonBody, err := json.Marshal(createDwollaTokenRequest{
-		ClientID:    c.clientID,
-		Secret:      c.secret,
-		AccessToken: accessToken,
-		AccountID:   accountID,
-	})
-	if err != nil {
-		return resp, err
-	}
-
-	err = c.Call("/processor/dwolla/processor_token/create", jsonBody, &resp)
-	return resp, err
-
+// CreateApexToken is used to create a new Apex processor token.
+func (c *Client) CreateApexToken(accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
+	return c.CreateProcessorToken("/processor/apex/processor_token/create", accessToken, accountID)
 }
 
-func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp CreateOcrolusTokenResponse, err error) {
-	if accessToken == "" || accountID == "" {
-		return resp, errors.New("/processor/ocrolus/processor_token/create - access token and account ID must be specified")
-	}
-
-	jsonBody, err := json.Marshal(createOcrolusTokenRequest{
-		ClientID:    c.clientID,
-		Secret:      c.secret,
-		AccessToken: accessToken,
-		AccountID:   accountID,
-	})
-	if err != nil {
-		return resp, err
-	}
-
-	err = c.Call("/processor/ocrolus/processor_token/create", jsonBody, &resp)
-	return resp, err
-
+// CreateDwollaToken is used to create a new Dwolla processor token.
+func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
+	return c.CreateProcessorToken("/processor/dwolla/processor_token/create", accessToken, accountID)
 }
 
+// CreateOcrolusToken is used to create a new Ocrolus processor token.
+func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
+	return c.CreateProcessorToken("/processor/ocrolus/processor_token/create", accessToken, accountID)
+}
+
+// CreateStripeToken is used to create a new Stripe bank account token.
 func (c *Client) CreateStripeToken(accessToken, accountID string) (resp CreateStripeTokenResponse, err error) {
 	if accessToken == "" || accountID == "" {
 		return resp, errors.New("/processor/stripe/bank_account_token/create - access token and account ID must be specified")

--- a/plaid/processor_test.go
+++ b/plaid/processor_test.go
@@ -48,6 +48,26 @@ func TestCreateDwollaToken(t *testing.T) {
 	assert.True(t, strings.HasPrefix(dwollaTokenResp.ProcessorToken, "processor-sandbox-"))
 }
 
+func TestCreateOcrolusToken(t *testing.T) {
+	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	assert.Nil(t, err)
+
+	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	assert.Nil(t, err)
+
+	// get test account
+	options := GetAccountsOptions{
+		AccountIDs: []string{},
+	}
+	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	assert.Nil(t, err)
+	accountID := accountsResp.Accounts[0].AccountID
+
+	ocrolusTokenResp, err := testClient.CreateOcrolusToken(tokenResp.AccessToken, accountID)
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(ocrolusTokenResp.ProcessorToken, "processor-sandbox-"))
+}
+
 func TestCreateStripeToken(t *testing.T) {
 	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
 	assert.Nil(t, err)


### PR DESCRIPTION
## Changes

* Adds the function `CreateOcrolusToken` and related test.
* Refactors the shared logic in the `CreateApexToken `, `CreateDwollaToken`, and `CreateOcrolusToken` functions into the `CreateProcessorToken` function. I've left the three processor-specific functions exposed for ease of integration. I also left the Stripe structs and function as-is since Stripe uses bank account tokens instead of processor tokens.

Do we want to export the `CreateProcessorToken` function? Or should we make it unexported?