### PR TITLE
Make all calls context-aware.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -28,57 +29,57 @@ func main() {
 	handleError(err)
 
 	// POST /institutions/get
-	instsResp, err := client.GetInstitutions(5, 0)
+	instsResp, err := client.GetInstitutions(context.Background(), 5, 0)
 	handleError(err)
 	fmt.Println(instsResp.Institutions[0].Name, "has products:", instsResp.Institutions[0].Products)
 
 	// POST /institutions/get_by_id
-	instResp, err := client.GetInstitutionByID(instsResp.Institutions[0].ID)
+	instResp, err := client.GetInstitutionByID(context.Background(), instsResp.Institutions[0].ID)
 	handleError(err)
 	fmt.Println(instResp.Institution.Name, "has MFA:", instResp.Institution.MFA)
 
 	// POST /institutions/search
-	instSearchResp, err := client.SearchInstitutions("Ally", []string{"transactions"})
+	instSearchResp, err := client.SearchInstitutions(context.Background(), "Ally", []string{"transactions"})
 	handleError(err)
 	fmt.Println(instSearchResp.Institutions[0].Name, "has ID:", instSearchResp.Institutions[0].ID)
 
 	// POST /categories/get
-	categoriesResp, err := client.GetCategories()
+	categoriesResp, err := client.GetCategories(context.Background())
 	handleError(err)
 	fmt.Println("Category group", categoriesResp.Categories[0].Group, "has items:", categoriesResp.Categories[0].Hierarchy)
 
 	// POST /sandbox/public_token/create
-	publicTokenResp, err := client.CreateSandboxPublicToken(instResp.Institution.ID, []string{"auth", "transactions"})
+	publicTokenResp, err := client.CreateSandboxPublicToken(context.Background(), instResp.Institution.ID, []string{"auth", "transactions"})
 	handleError(err)
 	fmt.Println("Created sandbox public token:", publicTokenResp.PublicToken)
 
 	// POST /item/public_token/exchange
-	accessTokenResp, err := client.ExchangePublicToken(publicTokenResp.PublicToken)
+	accessTokenResp, err := client.ExchangePublicToken(context.Background(), publicTokenResp.PublicToken)
 	handleError(err)
 	fmt.Println("Public token -> Access Token", accessTokenResp.AccessToken, "for item:", accessTokenResp.ItemID)
 
 	// POST /accounts/balance/get
-	balanceResp, err := client.GetBalances(accessTokenResp.AccessToken)
+	balanceResp, err := client.GetBalances(context.Background(), accessTokenResp.AccessToken)
 	handleError(err)
 	fmt.Println("Account with name", balanceResp.Accounts[0].Name, "has available balance", balanceResp.Accounts[0].Balances.Available)
 
 	// POST /accounts/get
-	accountsResp, err := client.GetAccounts(accessTokenResp.AccessToken)
+	accountsResp, err := client.GetAccounts(context.Background(), accessTokenResp.AccessToken)
 	handleError(err)
 	fmt.Println("Access token is associated with", len(accountsResp.Accounts), "accounts")
 
 	// POST /auth/get
-	authResp, err := client.GetAuth(accessTokenResp.AccessToken)
+	authResp, err := client.GetAuth(context.Background(), accessTokenResp.AccessToken)
 	handleError(err)
 	fmt.Println("Account has number:", authResp.Numbers.ACH[0].Account)
 
 	// POST /transactions/get
-	transactionsResp, err := client.GetTransactions(accessTokenResp.AccessToken, "2010-01-01", "2018-01-01")
+	transactionsResp, err := client.GetTransactions(context.Background(), accessTokenResp.AccessToken, "2010-01-01", "2018-01-01")
 	if plaidErr, ok := err.(plaid.Error); ok {
 		// Poll until transactions are ready
 		for ok && plaidErr.ErrorCode == "PRODUCT_NOT_READY" {
 			time.Sleep(5 * time.Second)
-			transactionsResp, err = client.GetTransactions(accessTokenResp.AccessToken, "2010-01-01", "2018-01-01")
+			transactionsResp, err = client.GetTransactions(context.Background(), accessTokenResp.AccessToken, "2010-01-01", "2018-01-01")
 			plaidErr, ok = err.(plaid.Error)
 		}
 		handleError(err)

--- a/plaid/accounts.go
+++ b/plaid/accounts.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -80,7 +81,7 @@ type getAccountsRequest struct {
 type GetAccountsResponse struct {
 	APIResponse
 	Accounts []Account `json:"accounts"`
-	Item Item `json:"item"`
+	Item     Item      `json:"item"`
 }
 
 type GetAccountsOptions struct {
@@ -93,16 +94,16 @@ type GetBalancesOptions struct {
 
 // GetBalances returns the real-time balance for each of an Item's accounts.
 // See https://plaid.com/docs/api/#balance.
-func (c *Client) GetBalances(accessToken string) (resp GetBalancesResponse, err error) {
+func (c *Client) GetBalances(ctx context.Context, accessToken string) (resp GetBalancesResponse, err error) {
 	options := GetBalancesOptions{
 		AccountIDs: []string{},
 	}
-	return c.GetBalancesWithOptions(accessToken, options)
+	return c.GetBalancesWithOptions(ctx, accessToken, options)
 }
 
 // GetBalancesWithOptions returns the real-time balance for each of an Item's accounts.
 // See https://plaid.com/docs/api/#balance.
-func (c *Client) GetBalancesWithOptions(accessToken string, options GetBalancesOptions) (resp GetBalancesResponse, err error) {
+func (c *Client) GetBalancesWithOptions(ctx context.Context, accessToken string, options GetBalancesOptions) (resp GetBalancesResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/accounts/balance/get - access token must be specified")
 	}
@@ -119,13 +120,13 @@ func (c *Client) GetBalancesWithOptions(accessToken string, options GetBalancesO
 		return resp, err
 	}
 
-	err = c.Call("/accounts/balance/get", jsonBody, &resp)
+	err = c.Call(ctx, "/accounts/balance/get", jsonBody, &resp)
 	return resp, err
 }
 
 // GetAccountsWithOptions retrieves accounts associated with an Item.
 // See https://plaid.com/docs/api/#accounts.
-func (c *Client) GetAccountsWithOptions(accessToken string, options GetAccountsOptions) (resp GetAccountsResponse, err error) {
+func (c *Client) GetAccountsWithOptions(ctx context.Context, accessToken string, options GetAccountsOptions) (resp GetAccountsResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/accounts/get - access token must be specified")
 	}
@@ -144,15 +145,15 @@ func (c *Client) GetAccountsWithOptions(accessToken string, options GetAccountsO
 		return resp, err
 	}
 
-	err = c.Call("/accounts/get", jsonBody, &resp)
+	err = c.Call(ctx, "/accounts/get", jsonBody, &resp)
 	return resp, err
 }
 
 // GetAccounts retrieves accounts associated with an Item.
 // See https://plaid.com/docs/api/#accounts.
-func (c *Client) GetAccounts(accessToken string) (resp GetAccountsResponse, err error) {
+func (c *Client) GetAccounts(ctx context.Context, accessToken string) (resp GetAccountsResponse, err error) {
 	options := GetAccountsOptions{
 		AccountIDs: []string{},
 	}
-	return c.GetAccountsWithOptions(accessToken, options)
+	return c.GetAccountsWithOptions(ctx, accessToken, options)
 }

--- a/plaid/accounts_test.go
+++ b/plaid/accounts_test.go
@@ -1,20 +1,21 @@
 package plaid
 
 import (
+	"context"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 )
 
 func TestGetAccounts(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 
 	// get all accounts
 	options := GetAccountsOptions{
 		AccountIDs: []string{},
 	}
-	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	accountsResp, err := testClient.GetAccountsWithOptions(context.Background(), tokenResp.AccessToken, options)
 	assert.Nil(t, err)
 	assert.NotNil(t, accountsResp.Accounts)
 	assert.Equal(t, len(accountsResp.Accounts), 8)
@@ -24,18 +25,18 @@ func TestGetAccounts(t *testing.T) {
 	options = GetAccountsOptions{
 		AccountIDs: []string{accountsResp.Accounts[0].AccountID},
 	}
-	accountsResp, err = testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	accountsResp, err = testClient.GetAccountsWithOptions(context.Background(), tokenResp.AccessToken, options)
 	assert.Nil(t, err)
 	assert.Equal(t, len(accountsResp.Accounts), 1)
 	assert.NotNil(t, accountsResp.Item)
 }
 
 func TestGetBalances(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 
 	// get all balances
-	balanceResp, err := testClient.GetBalances(tokenResp.AccessToken)
+	balanceResp, err := testClient.GetBalances(context.Background(), tokenResp.AccessToken)
 	assert.Nil(t, err)
 	assert.NotNil(t, balanceResp.Accounts)
 
@@ -43,7 +44,7 @@ func TestGetBalances(t *testing.T) {
 	options := GetBalancesOptions{
 		AccountIDs: []string{balanceResp.Accounts[0].AccountID},
 	}
-	balanceResp, err = testClient.GetBalancesWithOptions(tokenResp.AccessToken, options)
+	balanceResp, err = testClient.GetBalancesWithOptions(context.Background(), tokenResp.AccessToken, options)
 	assert.Nil(t, err)
 	assert.Equal(t, len(balanceResp.Accounts), 1)
 }

--- a/plaid/assets.go
+++ b/plaid/assets.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -67,7 +68,7 @@ type CreateAuditCopyTokenResponse struct {
 	AuditCopyToken string `json:"audit_copy_token"`
 }
 
-func (c *Client) GetAssetReport(assetReportToken string) (resp GetAssetReportResponse, err error) {
+func (c *Client) GetAssetReport(ctx context.Context, assetReportToken string) (resp GetAssetReportResponse, err error) {
 	if assetReportToken == "" {
 		return resp, errors.New("/asset_report/get - asset report token must be specified")
 	}
@@ -82,11 +83,11 @@ func (c *Client) GetAssetReport(assetReportToken string) (resp GetAssetReportRes
 		return resp, err
 	}
 
-	err = c.Call("/asset_report/get", jsonBody, &resp)
+	err = c.Call(ctx, "/asset_report/get", jsonBody, &resp)
 	return resp, err
 }
 
-func (c *Client) CreateAuditCopy(assetReportToken, auditorID string) (resp CreateAuditCopyTokenResponse, err error) {
+func (c *Client) CreateAuditCopy(ctx context.Context, assetReportToken, auditorID string) (resp CreateAuditCopyTokenResponse, err error) {
 	if assetReportToken == "" || auditorID == "" {
 		return resp, errors.New("/asset_report/audit_copy/create - asset report token and auditor id must be specified")
 	}
@@ -102,11 +103,11 @@ func (c *Client) CreateAuditCopy(assetReportToken, auditorID string) (resp Creat
 		return resp, err
 	}
 
-	err = c.Call("/asset_report/audit_copy/create", jsonBody, &resp)
+	err = c.Call(ctx, "/asset_report/audit_copy/create", jsonBody, &resp)
 	return resp, err
 }
 
-func (c *Client) RemoveAssetReport(assetReportToken string) (resp RemoveAssetReportResponse, err error) {
+func (c *Client) RemoveAssetReport(ctx context.Context, assetReportToken string) (resp RemoveAssetReportResponse, err error) {
 	if assetReportToken == "" {
 		return resp, errors.New("/asset_report/remove - asset report token must be specified")
 	}
@@ -121,6 +122,6 @@ func (c *Client) RemoveAssetReport(assetReportToken string) (resp RemoveAssetRep
 		return resp, err
 	}
 
-	err = c.Call("/asset_report/remove", jsonBody, &resp)
+	err = c.Call(ctx, "/asset_report/remove", jsonBody, &resp)
 	return resp, err
 }

--- a/plaid/auth.go
+++ b/plaid/auth.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -36,7 +37,7 @@ type GetAuthOptions struct {
 // GetAuthWithOptions retrieves bank account and routing numbers associated with an Item's
 // checking and savings accounts, along with other information.
 // See https://plaid.com/docs/api/#auth.
-func (c *Client) GetAuthWithOptions(accessToken string, options GetAuthOptions) (resp GetAuthResponse, err error) {
+func (c *Client) GetAuthWithOptions(ctx context.Context, accessToken string, options GetAuthOptions) (resp GetAuthResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/auth/get - access token must be specified")
 	}
@@ -55,16 +56,16 @@ func (c *Client) GetAuthWithOptions(accessToken string, options GetAuthOptions) 
 		return resp, err
 	}
 
-	err = c.Call("/auth/get", jsonBody, &resp)
+	err = c.Call(ctx, "/auth/get", jsonBody, &resp)
 	return resp, err
 }
 
 // GetAuth retrieves bank account and routing numbers associated with an Item's
 // checking and savings accounts, along with other information.
 // See https://plaid.com/docs/api/#auth.
-func (c *Client) GetAuth(accessToken string) (resp GetAuthResponse, err error) {
+func (c *Client) GetAuth(ctx context.Context, accessToken string) (resp GetAuthResponse, err error) {
 	options := GetAuthOptions{
 		AccountIDs: []string{},
 	}
-	return c.GetAuthWithOptions(accessToken, options)
+	return c.GetAuthWithOptions(ctx, accessToken, options)
 }

--- a/plaid/auth_test.go
+++ b/plaid/auth_test.go
@@ -1,15 +1,16 @@
 package plaid
 
 import (
+	"context"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 )
 
 func TestGetAuth(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	authResp, err := testClient.GetAuth(tokenResp.AccessToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
+	authResp, err := testClient.GetAuth(context.Background(), tokenResp.AccessToken)
 
 	// get auth for all accounts
 	assert.Nil(t, err)
@@ -20,6 +21,6 @@ func TestGetAuth(t *testing.T) {
 	options := GetAccountsOptions{
 		AccountIDs: []string{authResp.Accounts[0].AccountID},
 	}
-	accountsResp, _ := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	accountsResp, _ := testClient.GetAccountsWithOptions(context.Background(), tokenResp.AccessToken, options)
 	assert.Equal(t, len(accountsResp.Accounts), 1)
 }

--- a/plaid/categories.go
+++ b/plaid/categories.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 )
 
@@ -17,9 +18,9 @@ type GetCategoriesResponse struct {
 
 // GetCategories returns information for all categories.
 // See https://plaid.com/docs/api/#category-overview.
-func (c *Client) GetCategories() (resp GetCategoriesResponse, err error) {
+func (c *Client) GetCategories(ctx context.Context) (resp GetCategoriesResponse, err error) {
 	jsonBody, _ := json.Marshal(nil)
 
-	err = c.Call("/categories/get", jsonBody, &resp)
+	err = c.Call(ctx, "/categories/get", jsonBody, &resp)
 	return resp, err
 }

--- a/plaid/categories_test.go
+++ b/plaid/categories_test.go
@@ -1,13 +1,14 @@
 package plaid
 
 import (
+	"context"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 )
 
 func TestGetCategories(t *testing.T) {
-	categoriesResp, err := testClient.GetCategories()
+	categoriesResp, err := testClient.GetCategories(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, categoriesResp.Categories[0].CategoryID, "10000000")
 	assert.Equal(t, categoriesResp.Categories[0].Group, "special")

--- a/plaid/holdings.go
+++ b/plaid/holdings.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -58,16 +59,16 @@ type GetHoldingsResponse struct {
 
 // GetHoldings retrieves various account holdings for investment accounts.
 // See https://plaid.com/docs/api/#holdings.
-func (c *Client) GetHoldings(accessToken string) (resp GetHoldingsResponse, err error) {
+func (c *Client) GetHoldings(ctx context.Context, accessToken string) (resp GetHoldingsResponse, err error) {
 	options := GetHoldingsOptions{
 		AccountIDs: []string{},
 	}
-	return c.GetHoldingsWithOptions(accessToken, options)
+	return c.GetHoldingsWithOptions(ctx, accessToken, options)
 }
 
 // GetHoldingsWithOptions retrieves various account holdings for investment accounts.
 // See https://plaid.com/docs/api/#holdings.
-func (c *Client) GetHoldingsWithOptions(accessToken string, options GetHoldingsOptions) (resp GetHoldingsResponse, err error) {
+func (c *Client) GetHoldingsWithOptions(ctx context.Context, accessToken string, options GetHoldingsOptions) (resp GetHoldingsResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/investments/holdings/get - access token must be specified")
 	}
@@ -85,6 +86,6 @@ func (c *Client) GetHoldingsWithOptions(accessToken string, options GetHoldingsO
 		return resp, err
 	}
 
-	err = c.Call("/investments/holdings/get", jsonBody, &resp)
+	err = c.Call(ctx, "/investments/holdings/get", jsonBody, &resp)
 	return resp, err
 }

--- a/plaid/holdings_test.go
+++ b/plaid/holdings_test.go
@@ -1,18 +1,19 @@
 package plaid
 
 import (
+	"context"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 )
 
 func TestGetHoldings(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, []string{"investments"})
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, []string{"investments"})
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 	options := GetHoldingsOptions{
 		AccountIDs: []string{},
 	}
-	holdingsResp, err := testClient.GetHoldingsWithOptions(tokenResp.AccessToken, options)
+	holdingsResp, err := testClient.GetHoldingsWithOptions(context.Background(), tokenResp.AccessToken, options)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, holdingsResp.Accounts)
@@ -24,7 +25,7 @@ func TestGetHoldings(t *testing.T) {
 	options = GetHoldingsOptions{
 		AccountIDs: []string{holdingsResp.Accounts[0].AccountID},
 	}
-	holdingsResp, err = testClient.GetHoldingsWithOptions(tokenResp.AccessToken, options)
+	holdingsResp, err = testClient.GetHoldingsWithOptions(context.Background(), tokenResp.AccessToken, options)
 	assert.Nil(t, err)
 	assert.Equal(t, len(holdingsResp.Accounts), 1)
 	assert.NotNil(t, holdingsResp.Securities)

--- a/plaid/identity.go
+++ b/plaid/identity.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -57,7 +58,7 @@ type GetIdentityResponse struct {
 // GetIdentity retrieves various account holder information on file with an
 // associated financial institution.
 // See https://plaid.com/docs/api/#identity.
-func (c *Client) GetIdentity(accessToken string) (resp GetIdentityResponse, err error) {
+func (c *Client) GetIdentity(ctx context.Context, accessToken string) (resp GetIdentityResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/identity/get - access token must be specified")
 	}
@@ -72,6 +73,6 @@ func (c *Client) GetIdentity(accessToken string) (resp GetIdentityResponse, err 
 		return resp, err
 	}
 
-	err = c.Call("/identity/get", jsonBody, &resp)
+	err = c.Call(ctx, "/identity/get", jsonBody, &resp)
 	return resp, err
 }

--- a/plaid/identity_test.go
+++ b/plaid/identity_test.go
@@ -1,15 +1,16 @@
 package plaid
 
 import (
+	"context"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 )
 
 func TestGetIdentity(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	identityResp, err := testClient.GetIdentity(tokenResp.AccessToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
+	identityResp, err := testClient.GetIdentity(context.Background(), tokenResp.AccessToken)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, identityResp.Accounts)

--- a/plaid/income.go
+++ b/plaid/income.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -35,7 +36,7 @@ type GetIncomeResponse struct {
 
 // GetIncome retrieves information pertaining to an Item's income.
 // See https://plaid.com/docs/api/#income.
-func (c *Client) GetIncome(accessToken string) (resp GetIncomeResponse, err error) {
+func (c *Client) GetIncome(ctx context.Context, accessToken string) (resp GetIncomeResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/income/get - access token must be specified")
 	}
@@ -50,6 +51,6 @@ func (c *Client) GetIncome(accessToken string) (resp GetIncomeResponse, err erro
 		return resp, err
 	}
 
-	err = c.Call("/income/get", jsonBody, &resp)
+	err = c.Call(ctx, "/income/get", jsonBody, &resp)
 	return resp, err
 }

--- a/plaid/income_test.go
+++ b/plaid/income_test.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,14 +9,14 @@ import (
 )
 
 func TestGetIncome(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	incomeResp, err := testClient.GetIncome(tokenResp.AccessToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
+	incomeResp, err := testClient.GetIncome(context.Background(), tokenResp.AccessToken)
 
 	if plaidErr, ok := err.(Error); ok {
 		for ok && plaidErr.ErrorCode == "PRODUCT_NOT_READY" {
 			time.Sleep(5 * time.Second)
-			incomeResp, err = testClient.GetIncome(tokenResp.AccessToken)
+			incomeResp, err = testClient.GetIncome(context.Background(), tokenResp.AccessToken)
 			plaidErr, ok = err.(Error)
 		}
 	}

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"time"
@@ -105,14 +106,16 @@ type SearchInstitutionsResponse struct {
 // GetInstitutionByID returns information for a single institution given an ID.
 // See https://plaid.com/docs/api/#institutions-by-id.
 func (c *Client) GetInstitutionByID(
+	ctx context.Context,
 	id string,
 ) (resp GetInstitutionByIDResponse, err error) {
-	return c.GetInstitutionByIDWithOptions(id, GetInstitutionByIDOptions{})
+	return c.GetInstitutionByIDWithOptions(ctx, id, GetInstitutionByIDOptions{})
 }
 
 // GetInstitutionByIDWithOptions returns information for a single institution given an ID.
 // See https://plaid.com/docs/api/#institutions-by-id.
 func (c *Client) GetInstitutionByIDWithOptions(
+	ctx context.Context,
 	id string,
 	options GetInstitutionByIDOptions,
 ) (resp GetInstitutionByIDResponse, err error) {
@@ -130,19 +133,20 @@ func (c *Client) GetInstitutionByIDWithOptions(
 		return resp, err
 	}
 
-	err = c.Call("/institutions/get_by_id", jsonBody, &resp)
+	err = c.Call(ctx, "/institutions/get_by_id", jsonBody, &resp)
 	return resp, err
 }
 
 // GetInstitutions returns information for all institutions supported by Plaid.
 // See https://plaid.com/docs/api/#all-institutions.
-func (c *Client) GetInstitutions(count, offset int) (resp GetInstitutionsResponse, err error) {
-	return c.GetInstitutionsWithOptions(count, offset, GetInstitutionsOptions{})
+func (c *Client) GetInstitutions(ctx context.Context, count, offset int) (resp GetInstitutionsResponse, err error) {
+	return c.GetInstitutionsWithOptions(ctx, count, offset, GetInstitutionsOptions{})
 }
 
 // GetInstitutionsWithOptions returns information for all institutions supported by Plaid.
 // See https://plaid.com/docs/api/#all-institutions.
 func (c *Client) GetInstitutionsWithOptions(
+	ctx context.Context,
 	count int,
 	offset int,
 	options GetInstitutionsOptions,
@@ -163,7 +167,7 @@ func (c *Client) GetInstitutionsWithOptions(
 		return resp, err
 	}
 
-	err = c.Call("/institutions/get", jsonBody, &resp)
+	err = c.Call(ctx, "/institutions/get", jsonBody, &resp)
 	return resp, err
 }
 
@@ -171,16 +175,18 @@ func (c *Client) GetInstitutionsWithOptions(
 // supported products.
 // See https://plaid.com/docs/api/#institution-search.
 func (c *Client) SearchInstitutions(
+	ctx context.Context,
 	query string,
 	products []string,
 ) (resp SearchInstitutionsResponse, err error) {
-	return c.SearchInstitutionsWithOptions(query, products, SearchInstitutionsOptions{})
+	return c.SearchInstitutionsWithOptions(ctx, query, products, SearchInstitutionsOptions{})
 }
 
 // SearchInstitutionsWithOptions returns institutions corresponding to a query string and
 // supported products.
 // See https://plaid.com/docs/api/#institution-search.
 func (c *Client) SearchInstitutionsWithOptions(
+	ctx context.Context,
 	query string,
 	products []string,
 	options SearchInstitutionsOptions,
@@ -200,6 +206,6 @@ func (c *Client) SearchInstitutionsWithOptions(
 		return resp, err
 	}
 
-	err = c.Call("/institutions/search", jsonBody, &resp)
+	err = c.Call(ctx, "/institutions/search", jsonBody, &resp)
 	return resp, err
 }

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -14,7 +15,7 @@ func TestGetInstitutions(t *testing.T) {
 		GetInstitutionsOptions{IncludeOptionalMetadata: true},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
-			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, options)
+			instsResp, err := testClient.GetInstitutionsWithOptions(context.Background(), 2, 1, options)
 			assert.Nil(t, err)
 
 			expectedNames := []string{
@@ -45,7 +46,7 @@ func TestSearchInstitutions(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			p := []string{"transactions"}
-			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionName, p, options)
+			instsResp, err := testClient.SearchInstitutionsWithOptions(context.Background(), sandboxInstitutionName, p, options)
 			assert.Nil(t, err)
 			assert.True(t, len(instsResp.Institutions) > 0)
 
@@ -65,7 +66,7 @@ func TestGetInstitutionsByID(t *testing.T) {
 		GetInstitutionByIDOptions{IncludeOptionalMetadata: true, IncludeStatus: true},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
-			instResp, err := testClient.GetInstitutionByIDWithOptions(sandboxInstitution, options)
+			instResp, err := testClient.GetInstitutionByIDWithOptions(context.Background(), sandboxInstitution, options)
 			assert.Nil(t, err)
 			assert.True(t, len(instResp.Institution.Products) > 0)
 

--- a/plaid/investment_transactions.go
+++ b/plaid/investment_transactions.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -56,7 +57,7 @@ type getInvestmentTransactionsRequestOptions struct {
 
 // GetInvestmentTransactionsWithOptions retrieves user-authorized investment transaction data for investment-type accounts.
 // See https://plaid.com/docs/api/#investment-transactions.
-func (c *Client) GetInvestmentTransactionsWithOptions(accessToken string, options GetInvestmentTransactionsOptions) (resp GetInvestmentTransactionsResponse, err error) {
+func (c *Client) GetInvestmentTransactionsWithOptions(ctx context.Context, accessToken string, options GetInvestmentTransactionsOptions) (resp GetInvestmentTransactionsResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/investments/transacstions/get - access token must be specified")
 	}
@@ -84,13 +85,13 @@ func (c *Client) GetInvestmentTransactionsWithOptions(accessToken string, option
 		return resp, err
 	}
 
-	err = c.Call("/investments/transactions/get", jsonBody, &resp)
+	err = c.Call(ctx, "/investments/transactions/get", jsonBody, &resp)
 	return resp, err
 }
 
 // GetInvestmentTransactions retrieves user-authorized transaction data for investment-type accounts.
 // See https://plaid.com/docs/api/#investment-transactions.
-func (c *Client) GetInvestmentTransactions(accessToken, startDate, endDate string) (resp GetInvestmentTransactionsResponse, err error) {
+func (c *Client) GetInvestmentTransactions(ctx context.Context, accessToken, startDate, endDate string) (resp GetInvestmentTransactionsResponse, err error) {
 	options := GetInvestmentTransactionsOptions{
 		StartDate:  startDate,
 		EndDate:    endDate,
@@ -98,5 +99,5 @@ func (c *Client) GetInvestmentTransactions(accessToken, startDate, endDate strin
 		Count:      100,
 		Offset:     0,
 	}
-	return c.GetInvestmentTransactionsWithOptions(accessToken, options)
+	return c.GetInvestmentTransactionsWithOptions(ctx, accessToken, options)
 }

--- a/plaid/investment_transactions_test.go
+++ b/plaid/investment_transactions_test.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,16 +9,16 @@ import (
 )
 
 func TestGetInvestmentTransactions(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, []string{"investments"})
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, []string{"investments"})
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 	startDateString := time.Now().Add(-365 * 24 * time.Hour).Format(iso8601TimeFormat)
 	endDateString := time.Now().Format(iso8601TimeFormat)
-	investmentTransactionsResp, err := testClient.GetInvestmentTransactions(tokenResp.AccessToken, startDateString, endDateString)
+	investmentTransactionsResp, err := testClient.GetInvestmentTransactions(context.Background(), tokenResp.AccessToken, startDateString, endDateString)
 
 	if plaidErr, ok := err.(Error); ok {
 		for ok && plaidErr.ErrorCode == "PRODUCT_NOT_READY" {
 			time.Sleep(5 * time.Second)
-			investmentTransactionsResp, err = testClient.GetInvestmentTransactions(tokenResp.AccessToken, startDateString, endDateString)
+			investmentTransactionsResp, err = testClient.GetInvestmentTransactions(context.Background(), tokenResp.AccessToken, startDateString, endDateString)
 			plaidErr, ok = err.(Error)
 		}
 	}

--- a/plaid/item.go
+++ b/plaid/item.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -96,7 +97,7 @@ type ExchangePublicTokenResponse struct {
 
 // GetItem retrieves an item associated with an access token.
 // See https://plaid.com/docs/api/#retrieve-item.
-func (c *Client) GetItem(accessToken string) (resp GetItemResponse, err error) {
+func (c *Client) GetItem(ctx context.Context, accessToken string) (resp GetItemResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/item/get - access token must be specified")
 	}
@@ -111,13 +112,13 @@ func (c *Client) GetItem(accessToken string) (resp GetItemResponse, err error) {
 		return resp, err
 	}
 
-	err = c.Call("/item/get", jsonBody, &resp)
+	err = c.Call(ctx, "/item/get", jsonBody, &resp)
 	return resp, err
 }
 
 // RemoveItem removes an item associated with an access token.
 // See https://plaid.com/docs/api/#remove-an-item.
-func (c *Client) RemoveItem(accessToken string) (resp RemoveItemResponse, err error) {
+func (c *Client) RemoveItem(ctx context.Context, accessToken string) (resp RemoveItemResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/item/remove - access token must be specified")
 	}
@@ -132,13 +133,13 @@ func (c *Client) RemoveItem(accessToken string) (resp RemoveItemResponse, err er
 		return resp, err
 	}
 
-	err = c.Call("/item/remove", jsonBody, &resp)
+	err = c.Call(ctx, "/item/remove", jsonBody, &resp)
 	return resp, err
 }
 
 // UpdateItemWebhook updates the webhook associated with an Item.
 // See https://plaid.com/docs/api/#update-webhook.
-func (c *Client) UpdateItemWebhook(accessToken, webhook string) (resp UpdateItemWebhookResponse, err error) {
+func (c *Client) UpdateItemWebhook(ctx context.Context, accessToken, webhook string) (resp UpdateItemWebhookResponse, err error) {
 	if accessToken == "" || webhook == "" {
 		return resp, errors.New("/item/webhook/update - access token and webhook must be specified")
 	}
@@ -154,13 +155,13 @@ func (c *Client) UpdateItemWebhook(accessToken, webhook string) (resp UpdateItem
 		return resp, err
 	}
 
-	err = c.Call("/item/webhook/update", jsonBody, &resp)
+	err = c.Call(ctx, "/item/webhook/update", jsonBody, &resp)
 	return resp, err
 }
 
 // InvalidateAccessToken invalidates and rotates an access token.
 // See https://plaid.com/docs/api/#rotate-access-token.
-func (c *Client) InvalidateAccessToken(accessToken string) (resp InvalidateAccessTokenResponse, err error) {
+func (c *Client) InvalidateAccessToken(ctx context.Context, accessToken string) (resp InvalidateAccessTokenResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/item/access_token/invalidate - access token must be specified")
 	}
@@ -175,14 +176,14 @@ func (c *Client) InvalidateAccessToken(accessToken string) (resp InvalidateAcces
 		return resp, err
 	}
 
-	err = c.Call("/item/access_token/invalidate", jsonBody, &resp)
+	err = c.Call(ctx, "/item/access_token/invalidate", jsonBody, &resp)
 	return resp, err
 }
 
 // UpdateAccessTokenVersion generates an updated access token associated with
 // the legacy version of Plaid's API.
 // See https://plaid.com/docs/api/#update-access-token-version.
-func (c *Client) UpdateAccessTokenVersion(accessToken string) (resp UpdateAccessTokenVersionResponse, err error) {
+func (c *Client) UpdateAccessTokenVersion(ctx context.Context, accessToken string) (resp UpdateAccessTokenVersionResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/item/access_token/update_version - access token must be specified")
 	}
@@ -197,14 +198,14 @@ func (c *Client) UpdateAccessTokenVersion(accessToken string) (resp UpdateAccess
 		return resp, err
 	}
 
-	err = c.Call("/item/access_token/update_version", jsonBody, &resp)
+	err = c.Call(ctx, "/item/access_token/update_version", jsonBody, &resp)
 	return resp, err
 }
 
 // CreatePublicToken generates a one-time use public token which expires in
 // 30 minutes to update an Item.
 // See https://plaid.com/docs/api/#creating-public-tokens.
-func (c *Client) CreatePublicToken(accessToken string) (resp CreatePublicTokenResponse, err error) {
+func (c *Client) CreatePublicToken(ctx context.Context, accessToken string) (resp CreatePublicTokenResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/item/public_token/create - access token must be specified")
 	}
@@ -219,13 +220,13 @@ func (c *Client) CreatePublicToken(accessToken string) (resp CreatePublicTokenRe
 		return resp, err
 	}
 
-	err = c.Call("/item/public_token/create", jsonBody, &resp)
+	err = c.Call(ctx, "/item/public_token/create", jsonBody, &resp)
 	return resp, err
 }
 
 // ExchangePublicToken exchanges a public token for an access token.
 // See https://plaid.com/docs/api/#exchange-token-flow.
-func (c *Client) ExchangePublicToken(publicToken string) (resp ExchangePublicTokenResponse, err error) {
+func (c *Client) ExchangePublicToken(ctx context.Context, publicToken string) (resp ExchangePublicTokenResponse, err error) {
 	if publicToken == "" {
 		return resp, errors.New("/item/public_token/exchange - public token must be specified")
 	}
@@ -240,6 +241,6 @@ func (c *Client) ExchangePublicToken(publicToken string) (resp ExchangePublicTok
 		return resp, err
 	}
 
-	err = c.Call("/item/public_token/exchange", jsonBody, &resp)
+	err = c.Call(ctx, "/item/public_token/exchange", jsonBody, &resp)
 	return resp, err
 }

--- a/plaid/item_test.go
+++ b/plaid/item_test.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"strings"
@@ -18,27 +19,27 @@ func randomHex(n int) (string, error) {
 }
 
 func TestGetItem(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	itemResp, err := testClient.GetItem(tokenResp.AccessToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
+	itemResp, err := testClient.GetItem(context.Background(), tokenResp.AccessToken)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, itemResp.Item)
 }
 
 func TestRemoveItem(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	itemResp, err := testClient.RemoveItem(tokenResp.AccessToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
+	itemResp, err := testClient.RemoveItem(context.Background(), tokenResp.AccessToken)
 
 	assert.Nil(t, err)
 	assert.True(t, itemResp.Removed)
 }
 
 func TestUpdateItemWebhook(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	itemResp, err := testClient.UpdateItemWebhook(tokenResp.AccessToken, "https://plaid.com/webhook-test")
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
+	itemResp, err := testClient.UpdateItemWebhook(context.Background(), tokenResp.AccessToken, "https://plaid.com/webhook-test")
 
 	assert.Nil(t, err)
 	assert.NotNil(t, itemResp.Item)
@@ -46,9 +47,9 @@ func TestUpdateItemWebhook(t *testing.T) {
 }
 
 func TestInvalidateAccessToken(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	newTokenResp, err := testClient.InvalidateAccessToken(tokenResp.AccessToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
+	newTokenResp, err := testClient.InvalidateAccessToken(context.Background(), tokenResp.AccessToken)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, newTokenResp.NewAccessToken)
@@ -56,23 +57,23 @@ func TestInvalidateAccessToken(t *testing.T) {
 
 func TestUpdateAccessTokenVersion(t *testing.T) {
 	invalidToken, _ := randomHex(80)
-	newTokenResp, err := testClient.InvalidateAccessToken(invalidToken)
+	newTokenResp, err := testClient.InvalidateAccessToken(context.Background(), invalidToken)
 	assert.NotNil(t, err)
 	assert.True(t, newTokenResp.NewAccessToken == "")
 }
 
 func TestCreatePublicToken(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	publicTokenResp, err := testClient.CreatePublicToken(tokenResp.AccessToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
+	publicTokenResp, err := testClient.CreatePublicToken(context.Background(), tokenResp.AccessToken)
 
 	assert.Nil(t, err)
 	assert.True(t, strings.HasPrefix(publicTokenResp.PublicToken, "public-sandbox"))
 }
 
 func TestExchangePublicToken(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, err := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 
 	assert.Nil(t, err)
 	assert.True(t, strings.HasPrefix(tokenResp.AccessToken, "access-sandbox"))

--- a/plaid/liabilities.go
+++ b/plaid/liabilities.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -95,6 +96,7 @@ type GetLiabilitiesOptions struct {
 // GetLiabilitiesWithOptions retrieves liability data. See
 // https://plaid.com/docs/api/#liabilities.
 func (c *Client) GetLiabilitiesWithOptions(
+	ctx context.Context,
 	accessToken string,
 	options GetLiabilitiesOptions,
 ) (resp GetLiabilitiesResponse, err error) {
@@ -117,14 +119,14 @@ func (c *Client) GetLiabilitiesWithOptions(
 		return resp, err
 	}
 
-	err = c.Call("/liabilities/get", jsonBody, &resp)
+	err = c.Call(ctx, "/liabilities/get", jsonBody, &resp)
 	return resp, err
 }
 
 // GetLiabilities retrieves liability data. See
 // https://plaid.com/docs/api/#liabilities.
-func (c *Client) GetLiabilities(accessToken string) (resp GetLiabilitiesResponse, err error) {
-	return c.GetLiabilitiesWithOptions(accessToken, GetLiabilitiesOptions{
+func (c *Client) GetLiabilities(ctx context.Context, accessToken string) (resp GetLiabilitiesResponse, err error) {
+	return c.GetLiabilitiesWithOptions(ctx, accessToken, GetLiabilitiesOptions{
 		AccountIDs: []string{},
 	})
 }

--- a/plaid/liabilities_test.go
+++ b/plaid/liabilities_test.go
@@ -1,15 +1,16 @@
 package plaid
 
 import (
+	"context"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 )
 
 func TestGetLiabilities(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, []string{"liabilities"})
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	liabilitiesResp, err := testClient.GetLiabilities(tokenResp.AccessToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, []string{"liabilities"})
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
+	liabilitiesResp, err := testClient.GetLiabilities(context.Background(), tokenResp.AccessToken)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, liabilitiesResp.Accounts)
@@ -18,7 +19,7 @@ func TestGetLiabilities(t *testing.T) {
 	assert.Len(t, liabilitiesResp.Liabilities.Student, 1)
 
 	accountID := liabilitiesResp.Accounts[7].AccountID
-	liabilitiesResp, err = testClient.GetLiabilitiesWithOptions(tokenResp.AccessToken, GetLiabilitiesOptions{
+	liabilitiesResp, err = testClient.GetLiabilitiesWithOptions(context.Background(), tokenResp.AccessToken, GetLiabilitiesOptions{
 		AccountIDs: []string{accountID},
 	})
 	assert.Nil(t, err)

--- a/plaid/plaid.go
+++ b/plaid/plaid.go
@@ -2,6 +2,7 @@ package plaid
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -55,8 +56,8 @@ func NewClient(options ClientOptions) (client *Client, err error) {
 	}, nil
 }
 
-func (c *Client) Call(endpoint string, body []byte, v interface{}) error {
-	req, err := c.newRequest(endpoint, bytes.NewReader(body), v)
+func (c *Client) Call(ctx context.Context, endpoint string, body []byte, v interface{}) error {
+	req, err := c.newRequest(ctx, endpoint, bytes.NewReader(body), v)
 	if err != nil {
 		return err
 	}
@@ -65,7 +66,7 @@ func (c *Client) Call(endpoint string, body []byte, v interface{}) error {
 }
 
 // newRequest is used by Call to generate a http.Request with appropriate headers.
-func (c *Client) newRequest(endpoint string, body io.Reader, v interface{}) (*http.Request, error) {
+func (c *Client) newRequest(ctx context.Context, endpoint string, body io.Reader, v interface{}) (*http.Request, error) {
 	if !strings.HasPrefix(endpoint, "/") {
 		endpoint = "/" + endpoint
 	}
@@ -74,6 +75,9 @@ func (c *Client) newRequest(endpoint string, body io.Reader, v interface{}) (*ht
 	if err != nil {
 		return nil, err
 	}
+
+	// Add context.
+	req = req.WithContext(ctx)
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("User-Agent", "Plaid Go v"+internal.Version)

--- a/plaid/processor.go
+++ b/plaid/processor.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -33,7 +34,7 @@ type CreateStripeTokenResponse struct {
 	StripeBankAccountToken string `json:"stripe_bank_account_token"`
 }
 
-func (c *Client) createProcessorToken(apiEndpoint, accessToken, accountID string) (resp createProcessorTokenResponse, err error) {
+func (c *Client) createProcessorToken(ctx context.Context, apiEndpoint, accessToken, accountID string) (resp createProcessorTokenResponse, err error) {
 	if accessToken == "" || accountID == "" {
 		return resp, errors.New(apiEndpoint + " - access token and account ID must be specified")
 	}
@@ -48,30 +49,30 @@ func (c *Client) createProcessorToken(apiEndpoint, accessToken, accountID string
 		return resp, err
 	}
 
-	err = c.Call(apiEndpoint, jsonBody, &resp)
+	err = c.Call(ctx, apiEndpoint, jsonBody, &resp)
 	return resp, err
 }
 
 // CreateApexToken is used to create a new Apex processor token.
-func (c *Client) CreateApexToken(accessToken, accountID string) (resp CreateApexTokenResponse, err error) {
-	response, err := c.createProcessorToken("/processor/apex/processor_token/create", accessToken, accountID)
+func (c *Client) CreateApexToken(ctx context.Context, accessToken, accountID string) (resp CreateApexTokenResponse, err error) {
+	response, err := c.createProcessorToken(ctx, "/processor/apex/processor_token/create", accessToken, accountID)
 	return CreateApexTokenResponse(response), err
 }
 
 // CreateDwollaToken is used to create a new Dwolla processor token.
-func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp CreateDwollaTokenResponse, err error) {
-	response, err := c.createProcessorToken("/processor/dwolla/processor_token/create", accessToken, accountID)
+func (c *Client) CreateDwollaToken(ctx context.Context, accessToken, accountID string) (resp CreateDwollaTokenResponse, err error) {
+	response, err := c.createProcessorToken(ctx, "/processor/dwolla/processor_token/create", accessToken, accountID)
 	return CreateDwollaTokenResponse(response), err
 }
 
 // CreateOcrolusToken is used to create a new Ocrolus processor token.
-func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp CreateOcrolusTokenResponse, err error) {
-	response, err := c.createProcessorToken("/processor/ocrolus/processor_token/create", accessToken, accountID)
+func (c *Client) CreateOcrolusToken(ctx context.Context, accessToken, accountID string) (resp CreateOcrolusTokenResponse, err error) {
+	response, err := c.createProcessorToken(ctx, "/processor/ocrolus/processor_token/create", accessToken, accountID)
 	return CreateOcrolusTokenResponse(response), err
 }
 
 // CreateStripeToken is used to create a new Stripe bank account token.
-func (c *Client) CreateStripeToken(accessToken, accountID string) (resp CreateStripeTokenResponse, err error) {
+func (c *Client) CreateStripeToken(ctx context.Context, accessToken, accountID string) (resp CreateStripeTokenResponse, err error) {
 	if accessToken == "" || accountID == "" {
 		return resp, errors.New("/processor/stripe/bank_account_token/create - access token and account ID must be specified")
 	}
@@ -86,6 +87,6 @@ func (c *Client) CreateStripeToken(accessToken, accountID string) (resp CreateSt
 		return resp, err
 	}
 
-	err = c.Call("/processor/stripe/bank_account_token/create", jsonBody, &resp)
+	err = c.Call(ctx, "/processor/stripe/bank_account_token/create", jsonBody, &resp)
 	return resp, err
 }

--- a/plaid/processor_test.go
+++ b/plaid/processor_test.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -8,84 +9,84 @@ import (
 )
 
 func TestCreateApexToken(t *testing.T) {
-	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	sandboxResp, err := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
 	assert.Nil(t, err)
 
-	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	tokenResp, err := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 	assert.Nil(t, err)
 
 	// get test account
 	options := GetAccountsOptions{
 		AccountIDs: []string{},
 	}
-	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	accountsResp, err := testClient.GetAccountsWithOptions(context.Background(), tokenResp.AccessToken, options)
 	assert.Nil(t, err)
 	accountID := accountsResp.Accounts[0].AccountID
 
-	apexTokenResp, err := testClient.CreateApexToken(tokenResp.AccessToken, accountID)
+	apexTokenResp, err := testClient.CreateApexToken(context.Background(), tokenResp.AccessToken, accountID)
 	assert.Nil(t, err)
 	assert.True(t, strings.HasPrefix(apexTokenResp.ProcessorToken, "processor-sandbox-"))
 
 }
 
 func TestCreateDwollaToken(t *testing.T) {
-	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	sandboxResp, err := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
 	assert.Nil(t, err)
 
-	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	tokenResp, err := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 	assert.Nil(t, err)
 
 	// get test account
 	options := GetAccountsOptions{
 		AccountIDs: []string{},
 	}
-	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	accountsResp, err := testClient.GetAccountsWithOptions(context.Background(), tokenResp.AccessToken, options)
 	assert.Nil(t, err)
 	accountID := accountsResp.Accounts[0].AccountID
 
-	dwollaTokenResp, err := testClient.CreateDwollaToken(tokenResp.AccessToken, accountID)
+	dwollaTokenResp, err := testClient.CreateDwollaToken(context.Background(), tokenResp.AccessToken, accountID)
 	assert.Nil(t, err)
 	assert.True(t, strings.HasPrefix(dwollaTokenResp.ProcessorToken, "processor-sandbox-"))
 }
 
 func TestCreateOcrolusToken(t *testing.T) {
-	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	sandboxResp, err := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
 	assert.Nil(t, err)
 
-	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	tokenResp, err := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 	assert.Nil(t, err)
 
 	// get test account
 	options := GetAccountsOptions{
 		AccountIDs: []string{},
 	}
-	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	accountsResp, err := testClient.GetAccountsWithOptions(context.Background(), tokenResp.AccessToken, options)
 	assert.Nil(t, err)
 	accountID := accountsResp.Accounts[0].AccountID
 
-	ocrolusTokenResp, err := testClient.CreateOcrolusToken(tokenResp.AccessToken, accountID)
+	ocrolusTokenResp, err := testClient.CreateOcrolusToken(context.Background(), tokenResp.AccessToken, accountID)
 	assert.Nil(t, err)
 	assert.True(t, strings.HasPrefix(ocrolusTokenResp.ProcessorToken, "processor-sandbox-"))
 }
 
 func TestCreateStripeToken(t *testing.T) {
-	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	sandboxResp, err := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
 	assert.Nil(t, err)
 
-	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	tokenResp, err := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 	assert.Nil(t, err)
 
 	// get test account
 	options := GetAccountsOptions{
 		AccountIDs: []string{},
 	}
-	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	accountsResp, err := testClient.GetAccountsWithOptions(context.Background(), tokenResp.AccessToken, options)
 	assert.Nil(t, err)
 	accountID := accountsResp.Accounts[0].AccountID
 
 	t.Skip("CircleCI is not setup to work with stripe")
 
-	stripeTokenResp, err := testClient.CreateStripeToken(tokenResp.AccessToken, accountID)
+	stripeTokenResp, err := testClient.CreateStripeToken(context.Background(), tokenResp.AccessToken, accountID)
 	assert.Nil(t, err)
 	assert.True(t, strings.HasPrefix(stripeTokenResp.StripeBankAccountToken, "btok_"))
 }

--- a/plaid/sandbox.go
+++ b/plaid/sandbox.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -27,7 +28,7 @@ type ResetSandboxItemResponse struct {
 	ResetLogin bool `json:"reset_login"`
 }
 
-func (c *Client) CreateSandboxPublicToken(institutionID string, initialProducts []string) (resp CreateSandboxPublicTokenResponse, err error) {
+func (c *Client) CreateSandboxPublicToken(ctx context.Context, institutionID string, initialProducts []string) (resp CreateSandboxPublicTokenResponse, err error) {
 	if institutionID == "" || len(initialProducts) == 0 {
 		return resp, errors.New("/sandbox/public_token/create - institution id and initial products must be specified")
 	}
@@ -42,11 +43,11 @@ func (c *Client) CreateSandboxPublicToken(institutionID string, initialProducts 
 		return resp, err
 	}
 
-	err = c.Call("/sandbox/public_token/create", jsonBody, &resp)
+	err = c.Call(ctx, "/sandbox/public_token/create", jsonBody, &resp)
 	return resp, err
 }
 
-func (c *Client) ResetSandboxItem(accessToken string) (resp ResetSandboxItemResponse, err error) {
+func (c *Client) ResetSandboxItem(ctx context.Context, accessToken string) (resp ResetSandboxItemResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/sandbox/item/reset_login - access token must be specified")
 	}
@@ -61,6 +62,6 @@ func (c *Client) ResetSandboxItem(accessToken string) (resp ResetSandboxItemResp
 		return resp, err
 	}
 
-	err = c.Call("/sandbox/item/reset_login", jsonBody, &resp)
+	err = c.Call(ctx, "/sandbox/item/reset_login", jsonBody, &resp)
 	return resp, err
 }

--- a/plaid/sandbox_test.go
+++ b/plaid/sandbox_test.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -8,16 +9,16 @@ import (
 )
 
 func TestCreateSandboxPublicToken(t *testing.T) {
-	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	sandboxResp, err := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
 
 	assert.Nil(t, err)
 	assert.True(t, strings.HasPrefix(sandboxResp.PublicToken, "public-sandbox"))
 }
 
 func TestResetSandboxItem(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	resetResp, err := testClient.ResetSandboxItem(tokenResp.AccessToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
+	resetResp, err := testClient.ResetSandboxItem(context.Background(), tokenResp.AccessToken)
 
 	assert.Nil(t, err)
 	assert.True(t, resetResp.ResetLogin)

--- a/plaid/transactions.go
+++ b/plaid/transactions.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 )
@@ -82,7 +83,7 @@ type GetTransactionsOptions struct {
 
 // GetTransactionsWithOptions retrieves user-authorized transaction data for credit and depository-type accounts.
 // See https://plaid.com/docs/api/#transactions.
-func (c *Client) GetTransactionsWithOptions(accessToken string, options GetTransactionsOptions) (resp GetTransactionsResponse, err error) {
+func (c *Client) GetTransactionsWithOptions(ctx context.Context, accessToken string, options GetTransactionsOptions) (resp GetTransactionsResponse, err error) {
 	if options.StartDate == "" || options.EndDate == "" {
 		return resp, errors.New("/transactions/get - start date and end date must be specified")
 	}
@@ -107,13 +108,13 @@ func (c *Client) GetTransactionsWithOptions(accessToken string, options GetTrans
 		return resp, err
 	}
 
-	err = c.Call("/transactions/get", jsonBody, &resp)
+	err = c.Call(ctx, "/transactions/get", jsonBody, &resp)
 	return resp, err
 }
 
 // GetTransactions retrieves user-authorized transaction data for credit and depository-type accounts.
 // See https://plaid.com/docs/api/#transactions.
-func (c *Client) GetTransactions(accessToken, startDate, endDate string) (resp GetTransactionsResponse, err error) {
+func (c *Client) GetTransactions(ctx context.Context, accessToken, startDate, endDate string) (resp GetTransactionsResponse, err error) {
 	options := GetTransactionsOptions{
 		StartDate:  startDate,
 		EndDate:    endDate,
@@ -121,5 +122,5 @@ func (c *Client) GetTransactions(accessToken, startDate, endDate string) (resp G
 		Count:      100,
 		Offset:     0,
 	}
-	return c.GetTransactionsWithOptions(accessToken, options)
+	return c.GetTransactionsWithOptions(ctx, accessToken, options)
 }

--- a/plaid/transactions_test.go
+++ b/plaid/transactions_test.go
@@ -1,6 +1,7 @@
 package plaid
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,16 +11,16 @@ import (
 const iso8601TimeFormat = "2006-01-02"
 
 func TestGetTransactions(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 	startDate := time.Now().Add(-365 * 24 * time.Hour).Format(iso8601TimeFormat)
 	endDate := time.Now().Format(iso8601TimeFormat)
-	transactionsResp, err := testClient.GetTransactions(tokenResp.AccessToken, startDate, endDate)
+	transactionsResp, err := testClient.GetTransactions(context.Background(), tokenResp.AccessToken, startDate, endDate)
 
 	if plaidErr, ok := err.(Error); ok {
 		for ok && plaidErr.ErrorCode == "PRODUCT_NOT_READY" {
 			time.Sleep(5 * time.Second)
-			transactionsResp, err = testClient.GetTransactions(tokenResp.AccessToken, startDate, endDate)
+			transactionsResp, err = testClient.GetTransactions(context.Background(), tokenResp.AccessToken, startDate, endDate)
 			plaidErr, ok = err.(Error)
 		}
 	}
@@ -30,8 +31,8 @@ func TestGetTransactions(t *testing.T) {
 }
 
 func TestGetTransactionsWithOptions(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(context.Background(), sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(context.Background(), sandboxResp.PublicToken)
 
 	startDate := time.Now().Add(-365 * 24 * time.Hour).Format(iso8601TimeFormat)
 	endDate := time.Now().Format(iso8601TimeFormat)
@@ -42,12 +43,12 @@ func TestGetTransactionsWithOptions(t *testing.T) {
 		Count:      2,
 		Offset:     1,
 	}
-	transactionsResp, err := testClient.GetTransactionsWithOptions(tokenResp.AccessToken, options)
+	transactionsResp, err := testClient.GetTransactionsWithOptions(context.Background(), tokenResp.AccessToken, options)
 
 	if plaidErr, ok := err.(Error); ok {
 		for ok && plaidErr.ErrorCode == "PRODUCT_NOT_READY" {
 			time.Sleep(5 * time.Second)
-			transactionsResp, err = testClient.GetTransactionsWithOptions(tokenResp.AccessToken, options)
+			transactionsResp, err = testClient.GetTransactionsWithOptions(context.Background(), tokenResp.AccessToken, options)
 			plaidErr, ok = err.(Error)
 		}
 	}


### PR DESCRIPTION
Sponsored-by: BackendBenchmarking (backendb.com)

Fixes #71 

This PR is only temporarily pointing to master. This will be a breaking change because all API-calling functions now take an extra argument for `context.Context`. Before this can be merged, we should decide on how/if we want to handle versioning with go modules as discussed in #71 and update this PR to point to a new v2 or v3 branch.