### PR TITLE
Modularise: start at V2 - DO NOT MERGE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 .DS_Store
 vendor
 bin
-
-go.mod
-go.sum

--- a/v2/accounts.go
+++ b/v2/accounts.go
@@ -1,0 +1,158 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type Account struct {
+	AccountID          string          `json:"account_id"`
+	Balances           AccountBalances `json:"balances"`
+	Mask               string          `json:"mask"`
+	Name               string          `json:"name"`
+	OfficialName       string          `json:"official_name"`
+	Subtype            string          `json:"subtype"`
+	Type               string          `json:"type"`
+	VerificationStatus string          `json:"verification_status"`
+}
+
+type AccountBalances struct {
+	Available              float64 `json:"available"`
+	Current                float64 `json:"current"`
+	Limit                  float64 `json:"limit"`
+	ISOCurrencyCode        string  `json:"iso_currency_code"`
+	UnofficialCurrencyCode string  `json:"unofficial_currency_code"`
+}
+
+type ACHNumber struct {
+	Account     string `json:"account"`
+	AccountID   string `json:"account_id"`
+	Routing     string `json:"routing"`
+	WireRouting string `json:"wire_routing"`
+}
+
+type EFTNumber struct {
+	Account     string `json:"account"`
+	AccountID   string `json:"account_id"`
+	Institution string `json:"institution"`
+	Branch      string `json:"branch"`
+}
+
+type IBANNumber struct {
+	AccountID string `json:"account_id"`
+	IBAN      string `json:"iban"`
+	BIC       string `json:"bic"`
+}
+
+type BACSNumber struct {
+	AccountID string `json:"account_id"`
+	Account   string `json:"account"`
+	SortCode  string `json:"sort_code"`
+}
+
+type getBalancesRequestOptions struct {
+	AccountIDs []string `json:"account_ids,omitempty"`
+}
+
+type getBalancesRequest struct {
+	ClientID    string                    `json:"client_id"`
+	Secret      string                    `json:"secret"`
+	AccessToken string                    `json:"access_token"`
+	Options     getBalancesRequestOptions `json:"options,omitempty"`
+}
+
+type GetBalancesResponse struct {
+	APIResponse
+	Accounts []Account `json:"accounts"`
+}
+
+type getAccountsRequestOptions struct {
+	AccountIDs []string `json:"account_ids,omitempty"`
+}
+
+type getAccountsRequest struct {
+	ClientID    string                    `json:"client_id"`
+	Secret      string                    `json:"secret"`
+	AccessToken string                    `json:"access_token"`
+	Options     getAccountsRequestOptions `json:"options,omitempty"`
+}
+
+type GetAccountsResponse struct {
+	APIResponse
+	Accounts []Account `json:"accounts"`
+	Item Item `json:"item"`
+}
+
+type GetAccountsOptions struct {
+	AccountIDs []string
+}
+
+type GetBalancesOptions struct {
+	AccountIDs []string
+}
+
+// GetBalances returns the real-time balance for each of an Item's accounts.
+// See https://plaid.com/docs/api/#balance.
+func (c *Client) GetBalances(accessToken string) (resp GetBalancesResponse, err error) {
+	options := GetBalancesOptions{
+		AccountIDs: []string{},
+	}
+	return c.GetBalancesWithOptions(accessToken, options)
+}
+
+// GetBalancesWithOptions returns the real-time balance for each of an Item's accounts.
+// See https://plaid.com/docs/api/#balance.
+func (c *Client) GetBalancesWithOptions(accessToken string, options GetBalancesOptions) (resp GetBalancesResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/accounts/balance/get - access token must be specified")
+	}
+	req := getBalancesRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	}
+	if len(options.AccountIDs) > 0 {
+		req.Options.AccountIDs = options.AccountIDs
+	}
+	jsonBody, err := json.Marshal(req)
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/accounts/balance/get", jsonBody, &resp)
+	return resp, err
+}
+
+// GetAccountsWithOptions retrieves accounts associated with an Item.
+// See https://plaid.com/docs/api/#accounts.
+func (c *Client) GetAccountsWithOptions(accessToken string, options GetAccountsOptions) (resp GetAccountsResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/accounts/get - access token must be specified")
+	}
+
+	req := getAccountsRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	}
+	if len(options.AccountIDs) > 0 {
+		req.Options.AccountIDs = options.AccountIDs
+	}
+
+	jsonBody, err := json.Marshal(req)
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/accounts/get", jsonBody, &resp)
+	return resp, err
+}
+
+// GetAccounts retrieves accounts associated with an Item.
+// See https://plaid.com/docs/api/#accounts.
+func (c *Client) GetAccounts(accessToken string) (resp GetAccountsResponse, err error) {
+	options := GetAccountsOptions{
+		AccountIDs: []string{},
+	}
+	return c.GetAccountsWithOptions(accessToken, options)
+}

--- a/v2/accounts_test.go
+++ b/v2/accounts_test.go
@@ -1,0 +1,49 @@
+package plaid
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetAccounts(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+
+	// get all accounts
+	options := GetAccountsOptions{
+		AccountIDs: []string{},
+	}
+	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	assert.Nil(t, err)
+	assert.NotNil(t, accountsResp.Accounts)
+	assert.Equal(t, len(accountsResp.Accounts), 8)
+	assert.NotNil(t, accountsResp.Item)
+
+	// get selected accounts
+	options = GetAccountsOptions{
+		AccountIDs: []string{accountsResp.Accounts[0].AccountID},
+	}
+	accountsResp, err = testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	assert.Nil(t, err)
+	assert.Equal(t, len(accountsResp.Accounts), 1)
+	assert.NotNil(t, accountsResp.Item)
+}
+
+func TestGetBalances(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+
+	// get all balances
+	balanceResp, err := testClient.GetBalances(tokenResp.AccessToken)
+	assert.Nil(t, err)
+	assert.NotNil(t, balanceResp.Accounts)
+
+	// get selected accounts
+	options := GetBalancesOptions{
+		AccountIDs: []string{balanceResp.Accounts[0].AccountID},
+	}
+	balanceResp, err = testClient.GetBalancesWithOptions(tokenResp.AccessToken, options)
+	assert.Nil(t, err)
+	assert.Equal(t, len(balanceResp.Accounts), 1)
+}

--- a/v2/api.go
+++ b/v2/api.go
@@ -1,0 +1,6 @@
+package plaid
+
+// APIResponse is the base struct for all responses from the Plaid API.
+type APIResponse struct {
+	RequestID string `json:"request_id"`
+}

--- a/v2/api_test.go
+++ b/v2/api_test.go
@@ -1,0 +1,27 @@
+package plaid
+
+import (
+	"net/http"
+	"os"
+)
+
+// Credentials and parameters to be used for testing.
+var (
+	testClientID  = os.Getenv("PLAID_CLIENT_ID")
+	testSecret    = os.Getenv("PLAID_SECRET")
+	testPublicKey = os.Getenv("PLAID_PUBLIC_KEY")
+	testEnv       = Sandbox
+
+	sandboxInstitution     = "ins_109508"
+	sandboxInstitutionName = "First Platypus Bank"
+	testProducts           = []string{"auth", "identity", "income", "transactions"}
+)
+
+var testOptions = ClientOptions{
+	testClientID,
+	testSecret,
+	testPublicKey,
+	testEnv,
+	&http.Client{},
+}
+var testClient, _ = NewClient(testOptions)

--- a/v2/assets.go
+++ b/v2/assets.go
@@ -1,0 +1,126 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type AssetReport struct {
+	AssetReportID  string            `json:"asset_report_id"`
+	ClientReportID string            `json:"client_report_id"`
+	DateGenerated  string            `json:"date_generated"`
+	DaysRequested  int               `json:"days_requested"`
+	Items          []AssetReportItem `json:"items"`
+	User           AssetReportUser   `json:"user"`
+}
+
+type AssetReportItem struct {
+	Accounts        []Account `json:"accounts"`
+	DateLastUpdated string    `json:"date_last_updated"`
+	InstitutionID   string    `json:"institution_id"`
+	InstitutionName string    `json:"institution_name"`
+	ItemID          string    `json:"item_id"`
+}
+
+type AssetReportUser struct {
+	ClientID    string `json:"client_user_id"`
+	Email       string `json:"email"`
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	MiddleName  string `json:"middle_name"`
+	PhoneNumber string `json:"phone_number"`
+	SSN         string `json:"ssn"`
+}
+
+type getAssetReportRequest struct {
+	ClientID         string `json:"client_id"`
+	Secret           string `json:"secret"`
+	AssetReportToken string `json:"asset_report_token"`
+}
+
+type GetAssetReportResponse struct {
+	APIResponse
+	Report   AssetReport `json:"report"`
+	Warnings []string    `json:"warnings"`
+}
+
+type removeAssetReportRequest struct {
+	ClientID         string `json:"client_id"`
+	Secret           string `json:"secret"`
+	AssetReportToken string `json:"asset_report_token"`
+}
+
+type RemoveAssetReportResponse struct {
+	APIResponse
+	Removed bool `json:"removed"`
+}
+
+type createAuditCopyRequest struct {
+	ClientID         string `json:"client_id"`
+	Secret           string `json:"secret"`
+	AssetReportToken string `json:"asset_report_token"`
+	AuditorID        string `json:"auditor_id"`
+}
+
+type CreateAuditCopyTokenResponse struct {
+	APIResponse
+	AuditCopyToken string `json:"audit_copy_token"`
+}
+
+func (c *Client) GetAssetReport(assetReportToken string) (resp GetAssetReportResponse, err error) {
+	if assetReportToken == "" {
+		return resp, errors.New("/asset_report/get - asset report token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(getAssetReportRequest{
+		ClientID:         c.clientID,
+		Secret:           c.secret,
+		AssetReportToken: assetReportToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/asset_report/get", jsonBody, &resp)
+	return resp, err
+}
+
+func (c *Client) CreateAuditCopy(assetReportToken, auditorID string) (resp CreateAuditCopyTokenResponse, err error) {
+	if assetReportToken == "" || auditorID == "" {
+		return resp, errors.New("/asset_report/audit_copy/create - asset report token and auditor id must be specified")
+	}
+
+	jsonBody, err := json.Marshal(createAuditCopyRequest{
+		ClientID:         c.clientID,
+		Secret:           c.secret,
+		AssetReportToken: assetReportToken,
+		AuditorID:        auditorID,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/asset_report/audit_copy/create", jsonBody, &resp)
+	return resp, err
+}
+
+func (c *Client) RemoveAssetReport(assetReportToken string) (resp RemoveAssetReportResponse, err error) {
+	if assetReportToken == "" {
+		return resp, errors.New("/asset_report/remove - asset report token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(removeAssetReportRequest{
+		ClientID:         c.clientID,
+		Secret:           c.secret,
+		AssetReportToken: assetReportToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/asset_report/remove", jsonBody, &resp)
+	return resp, err
+}

--- a/v2/auth.go
+++ b/v2/auth.go
@@ -1,0 +1,70 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type getAuthRequestOptions struct {
+	AccountIDs []string `json:"account_ids"`
+}
+
+type getAuthRequest struct {
+	ClientID    string                `json:"client_id"`
+	Secret      string                `json:"secret"`
+	AccessToken string                `json:"access_token"`
+	Options     getAuthRequestOptions `json:"options,omitempty"`
+}
+
+type AccountNumberCollection struct {
+	ACH           []ACHNumber  `json:"ach"`
+	EFT           []EFTNumber  `json:"eft"`
+	International []IBANNumber `json:"international"`
+	BACS          []BACSNumber `json:"bacs"`
+}
+
+type GetAuthResponse struct {
+	APIResponse
+	Accounts []Account               `json:"accounts"`
+	Numbers  AccountNumberCollection `json:"numbers"`
+}
+
+type GetAuthOptions struct {
+	AccountIDs []string
+}
+
+// GetAuthWithOptions retrieves bank account and routing numbers associated with an Item's
+// checking and savings accounts, along with other information.
+// See https://plaid.com/docs/api/#auth.
+func (c *Client) GetAuthWithOptions(accessToken string, options GetAuthOptions) (resp GetAuthResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/auth/get - access token must be specified")
+	}
+
+	req := getAuthRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	}
+	if len(options.AccountIDs) > 0 {
+		req.Options.AccountIDs = options.AccountIDs
+	}
+
+	jsonBody, err := json.Marshal(req)
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/auth/get", jsonBody, &resp)
+	return resp, err
+}
+
+// GetAuth retrieves bank account and routing numbers associated with an Item's
+// checking and savings accounts, along with other information.
+// See https://plaid.com/docs/api/#auth.
+func (c *Client) GetAuth(accessToken string) (resp GetAuthResponse, err error) {
+	options := GetAuthOptions{
+		AccountIDs: []string{},
+	}
+	return c.GetAuthWithOptions(accessToken, options)
+}

--- a/v2/auth_test.go
+++ b/v2/auth_test.go
@@ -1,0 +1,25 @@
+package plaid
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetAuth(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	authResp, err := testClient.GetAuth(tokenResp.AccessToken)
+
+	// get auth for all accounts
+	assert.Nil(t, err)
+	assert.NotNil(t, authResp.Accounts)
+	assert.NotNil(t, authResp.Numbers)
+
+	// get auth for selected accounts
+	options := GetAccountsOptions{
+		AccountIDs: []string{authResp.Accounts[0].AccountID},
+	}
+	accountsResp, _ := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	assert.Equal(t, len(accountsResp.Accounts), 1)
+}

--- a/v2/categories.go
+++ b/v2/categories.go
@@ -1,0 +1,25 @@
+package plaid
+
+import (
+	"encoding/json"
+)
+
+type Category struct {
+	CategoryID string   `json:"category_id"`
+	Group      string   `json:"group"`
+	Hierarchy  []string `json:"hierarchy"`
+}
+
+type GetCategoriesResponse struct {
+	APIResponse
+	Categories []Category `json:"categories"`
+}
+
+// GetCategories returns information for all categories.
+// See https://plaid.com/docs/api/#category-overview.
+func (c *Client) GetCategories() (resp GetCategoriesResponse, err error) {
+	jsonBody, _ := json.Marshal(nil)
+
+	err = c.Call("/categories/get", jsonBody, &resp)
+	return resp, err
+}

--- a/v2/categories_test.go
+++ b/v2/categories_test.go
@@ -1,0 +1,14 @@
+package plaid
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetCategories(t *testing.T) {
+	categoriesResp, err := testClient.GetCategories()
+	assert.Nil(t, err)
+	assert.Equal(t, categoriesResp.Categories[0].CategoryID, "10000000")
+	assert.Equal(t, categoriesResp.Categories[0].Group, "special")
+}

--- a/v2/environments.go
+++ b/v2/environments.go
@@ -1,0 +1,24 @@
+package plaid
+
+type Environment string
+
+const (
+	Sandbox     Environment = "sandbox.plaid.com"
+	Development Environment = "development.plaid.com"
+	Production  Environment = "production.plaid.com"
+)
+
+var validEnvironments = [...]Environment{
+	Sandbox,
+	Development,
+	Production,
+}
+
+func (c Environment) Valid() bool {
+	for _, v := range validEnvironments {
+		if v == c {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/errors.go
+++ b/v2/errors.go
@@ -1,0 +1,23 @@
+package plaid
+
+import (
+	"fmt"
+)
+
+type Error struct {
+	APIResponse
+
+	// List of all errors: https://github.com/plaid/support/blob/master/errors.md
+	ErrorType      string `json:"error_type"`
+	ErrorCode      string `json:"error_code"`
+	ErrorMessage   string `json:"error_message"`
+	DisplayMessage string `json:"display_message"`
+
+	// StatusCode needs to be manually set from the response
+	StatusCode int
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf("Plaid Error - request ID: %s, http status: %d, type: %s, code: %s, message: %s",
+		e.RequestID, e.StatusCode, e.ErrorType, e.ErrorCode, e.ErrorMessage)
+}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,3 @@
+module github.com/myles-mcdonnell/plaid-go/v2
+
+go 1.13

--- a/v2/holdings.go
+++ b/v2/holdings.go
@@ -1,0 +1,90 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type Security struct {
+	SecurityID             string  `json:"security_id"`
+	CUSIP                  string  `json:"cusip"`
+	SEDOL                  string  `json:"sedol"`
+	ISIN                   string  `json:"isin"`
+	InstitutionSecurityID  string  `json:"institution_security_id"`
+	InstitutionID          string  `json:"institution_id"`
+	ProxySecurityID        string  `json:"proxy_security_id"`
+	Name                   string  `json:"name"`
+	TickerSymbol           string  `json:"ticker_symbol"`
+	IsCashEquivalent       bool    `json:"is_cash_equivalent"`
+	Type                   string  `json:"type"`
+	ClosePrice             float64 `json:"close_price"`
+	ClosePriceAsOf         string  `json:"close_price_as_of"`
+	ISOCurrencyCode        string  `json:"iso_currency_code"`
+	UnofficialCurrencyCode string  `json:"unofficial_currency_code"`
+}
+
+type Holding struct {
+	AccountID  string `json:"account_id"`
+	SecurityID string `json:"security_id"`
+
+	InstitutionValue     float64 `json:"institution_value"`
+	InstitutionPrice     float64 `json:"institution_price"`
+	Quantity             float64 `json:"quantity"`
+	InstitutionPriceAsOf string  `json:"institution_price_as_of"`
+	CostBasis            float64 `json:"cost_basis"`
+
+	ISOCurrencyCode        string `json:"iso_currency_code"`
+	UnofficialCurrencyCode string `json:"unofficial_currency_code"`
+}
+
+type getHoldingsRequest struct {
+	ClientID    string             `json:"client_id"`
+	Secret      string             `json:"secret"`
+	AccessToken string             `json:"access_token"`
+	Options     GetHoldingsOptions `json:"options,omitempty"`
+}
+
+type GetHoldingsOptions struct {
+	AccountIDs []string `json:"account_ids"`
+}
+
+type GetHoldingsResponse struct {
+	APIResponse
+	Accounts   []Account  `json:"accounts"`
+	Item       Item       `json:"item"`
+	Securities []Security `json:"securities"`
+	Holdings   []Holding  `json:"holdings"`
+}
+
+// GetHoldings retrieves various account holdings for investment accounts.
+// See https://plaid.com/docs/api/#holdings.
+func (c *Client) GetHoldings(accessToken string) (resp GetHoldingsResponse, err error) {
+	options := GetHoldingsOptions{
+		AccountIDs: []string{},
+	}
+	return c.GetHoldingsWithOptions(accessToken, options)
+}
+
+// GetHoldingsWithOptions retrieves various account holdings for investment accounts.
+// See https://plaid.com/docs/api/#holdings.
+func (c *Client) GetHoldingsWithOptions(accessToken string, options GetHoldingsOptions) (resp GetHoldingsResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/investments/holdings/get - access token must be specified")
+	}
+	req := getHoldingsRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	}
+	if len(options.AccountIDs) > 0 {
+		req.Options.AccountIDs = options.AccountIDs
+	}
+	jsonBody, err := json.Marshal(req)
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/investments/holdings/get", jsonBody, &resp)
+	return resp, err
+}

--- a/v2/holdings_test.go
+++ b/v2/holdings_test.go
@@ -1,0 +1,33 @@
+package plaid
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetHoldings(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, []string{"investments"})
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	options := GetHoldingsOptions{
+		AccountIDs: []string{},
+	}
+	holdingsResp, err := testClient.GetHoldingsWithOptions(tokenResp.AccessToken, options)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, holdingsResp.Accounts)
+	assert.NotNil(t, holdingsResp.Securities)
+	assert.NotNil(t, holdingsResp.Holdings)
+	assert.NotNil(t, holdingsResp.Item)
+
+	// Get only selected accounts.
+	options = GetHoldingsOptions{
+		AccountIDs: []string{holdingsResp.Accounts[0].AccountID},
+	}
+	holdingsResp, err = testClient.GetHoldingsWithOptions(tokenResp.AccessToken, options)
+	assert.Nil(t, err)
+	assert.Equal(t, len(holdingsResp.Accounts), 1)
+	assert.NotNil(t, holdingsResp.Securities)
+	assert.NotNil(t, holdingsResp.Holdings)
+	assert.NotNil(t, holdingsResp.Item)
+}

--- a/v2/identity.go
+++ b/v2/identity.go
@@ -1,0 +1,77 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type Identity struct {
+	Addresses    []Address     `json:"addresses"`
+	Emails       []Email       `json:"emails"`
+	Names        []string      `json:"names"`
+	PhoneNumbers []PhoneNumber `json:"phone_numbers"`
+}
+
+type Address struct {
+	Data    AddressData `json:"data"`
+	Primary bool        `json:"primary"`
+}
+
+type AddressData struct {
+	City       string `json:"city"`
+	Region     string `json:"region"`
+	Street     string `json:"street"`
+	PostalCode string `json:"postal_code"`
+	Country    string `json:"country"`
+}
+
+type Email struct {
+	Data    string `json:"data"`
+	Primary bool   `json:"primary"`
+	Type    string `json:"type"`
+}
+
+type PhoneNumber struct {
+	Primary bool   `json:"primary"`
+	Type    string `json:"type"`
+	Data    string `json:"data"`
+}
+
+type getIdentityRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+}
+
+type AccountWithOwners struct {
+	Owners []Identity `json:"owners"`
+	Account
+}
+
+type GetIdentityResponse struct {
+	APIResponse
+	Accounts []AccountWithOwners `json:"accounts"`
+	Item     Item                `json:"item"`
+}
+
+// GetIdentity retrieves various account holder information on file with an
+// associated financial institution.
+// See https://plaid.com/docs/api/#identity.
+func (c *Client) GetIdentity(accessToken string) (resp GetIdentityResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/identity/get - access token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(getIdentityRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/identity/get", jsonBody, &resp)
+	return resp, err
+}

--- a/v2/identity_test.go
+++ b/v2/identity_test.go
@@ -1,0 +1,20 @@
+package plaid
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetIdentity(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	identityResp, err := testClient.GetIdentity(tokenResp.AccessToken)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, identityResp.Accounts)
+	for _, acc := range identityResp.Accounts {
+		assert.NotNil(t, acc.Owners)
+		assert.True(t, len(acc.Owners) > 0)
+	}
+}

--- a/v2/income.go
+++ b/v2/income.go
@@ -1,0 +1,55 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type Income struct {
+	IncomeStreams                       []IncomeStream `json:"income_streams"`
+	LastYearIncome                      int            `json:"last_year_income"`
+	LastYearIncomeBeforeTax             int            `json:"last_year_income_before_tax"`
+	ProjectedYearlyIncome               int            `json:"projected_yearly_income"`
+	ProjectedYearlyIncomeBeforeTax      int            `json:"projected_yearly_income_before_tax"`
+	MaxNumberOfOverlappingIncomeStreams int            `json:"max_number_of_overlapping_income_streams"`
+	NumberOfIncomeStreams               int            `json:"number_of_income_streams"`
+}
+
+type IncomeStream struct {
+	Confidence    float64 `json:"confidence"`
+	Days          int     `json:"days"`
+	MonthlyIncome int     `json:"monthly_income"`
+	Name          string  `json:"name"`
+}
+
+type getIncomeRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+}
+
+type GetIncomeResponse struct {
+	APIResponse
+	Income Income `json:"income"`
+}
+
+// GetIncome retrieves information pertaining to an Item's income.
+// See https://plaid.com/docs/api/#income.
+func (c *Client) GetIncome(accessToken string) (resp GetIncomeResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/income/get - access token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(getIncomeRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/income/get", jsonBody, &resp)
+	return resp, err
+}

--- a/v2/income_test.go
+++ b/v2/income_test.go
@@ -1,0 +1,25 @@
+package plaid
+
+import (
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetIncome(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	incomeResp, err := testClient.GetIncome(tokenResp.AccessToken)
+
+	if plaidErr, ok := err.(Error); ok {
+		for ok && plaidErr.ErrorCode == "PRODUCT_NOT_READY" {
+			time.Sleep(5 * time.Second)
+			incomeResp, err = testClient.GetIncome(tokenResp.AccessToken)
+			plaidErr, ok = err.(Error)
+		}
+	}
+
+	assert.Nil(t, err)
+	assert.NotNil(t, incomeResp.Income)
+}

--- a/v2/institutions.go
+++ b/v2/institutions.go
@@ -1,0 +1,205 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+type Institution struct {
+	Credentials  []Credential `json:"credentials"`
+	HasMFA       bool         `json:"has_mfa"`
+	ID           string       `json:"institution_id"`
+	MFA          []string     `json:"mfa"`
+	Name         string       `json:"name"`
+	Products     []string     `json:"products"`
+	CountryCodes []string     `json:"country_codes"`
+
+	// Included when `options.include_status` is true.
+	InstitutionStatus *InstitutionStatus `json:"status,omitempty"`
+
+	// Included when `options.include_optional_metadata` is true.
+	PrimaryColor string `json:"primary_color,omitempty"`
+	// Included when `options.include_optional_metadata` is true.
+	URL string `json:"url,omitempty"`
+	// Included when `options.include_optional_metadata` is true.
+	Logo string `json:"logo,omitempty"`
+}
+
+type InstitutionStatus struct {
+	ItemLogins ItemLogins `json:"item_logins"`
+}
+
+type ItemLogins struct {
+	Status           string                     `json:"status"`
+	LastStatusChange time.Time                  `json:"last_status_change"`
+	Breakdown        InstitutionStatusBreakdown `json:"breakdown"`
+}
+
+type InstitutionStatusBreakdown struct {
+	Success          float64 `json:"success"`
+	ErrorPlaid       float64 `json:"error_plaid"`
+	ErrorInstitution float64 `json:"error_institution"`
+}
+
+type Credential struct {
+	Label string `json:"label"`
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+}
+
+type getInstitutionsRequest struct {
+	ClientID string                 `json:"client_id"`
+	Secret   string                 `json:"secret"`
+	Count    int                    `json:"count"`
+	Offset   int                    `json:"offset"`
+	Options  GetInstitutionsOptions `json:"options,omitempty"`
+}
+
+type GetInstitutionsOptions struct {
+	Products                []string `json:"products"`
+	IncludeOptionalMetadata bool     `json:"include_optional_metadata"`
+	CountryCodes            []string `json:"country_codes"`
+}
+
+type GetInstitutionsResponse struct {
+	APIResponse
+	Institutions []Institution `json:"institutions"`
+	Total        int           `json:"total"`
+}
+
+type getInstitutionByIDRequest struct {
+	ID        string                    `json:"institution_id"`
+	PublicKey string                    `json:"public_key"`
+	Options   GetInstitutionByIDOptions `json:"options,omitempty"`
+}
+
+type GetInstitutionByIDOptions struct {
+	IncludeOptionalMetadata bool `json:"include_optional_metadata"`
+	IncludeStatus           bool `json:"include_status"`
+}
+
+type GetInstitutionByIDResponse struct {
+	APIResponse
+	Institution Institution `json:"institution"`
+}
+
+type searchInstitutionsRequest struct {
+	Query     string                    `json:"query"`
+	Products  []string                  `json:"products"`
+	PublicKey string                    `json:"public_key"`
+	Options   SearchInstitutionsOptions `json:"options,omitempty"`
+}
+
+type SearchInstitutionsOptions struct {
+	IncludeOptionalMetadata bool                   `json:"include_optional_metadata"`
+	CountryCodes            []string               `json:"country_codes"`
+	AccountFilter           map[string]interface{} `json:"account_filter"`
+}
+
+type SearchInstitutionsResponse struct {
+	APIResponse
+	Institutions []Institution `json:"institutions"`
+}
+
+// GetInstitutionByID returns information for a single institution given an ID.
+// See https://plaid.com/docs/api/#institutions-by-id.
+func (c *Client) GetInstitutionByID(
+	id string,
+) (resp GetInstitutionByIDResponse, err error) {
+	return c.GetInstitutionByIDWithOptions(id, GetInstitutionByIDOptions{})
+}
+
+// GetInstitutionByIDWithOptions returns information for a single institution given an ID.
+// See https://plaid.com/docs/api/#institutions-by-id.
+func (c *Client) GetInstitutionByIDWithOptions(
+	id string,
+	options GetInstitutionByIDOptions,
+) (resp GetInstitutionByIDResponse, err error) {
+	if id == "" {
+		return resp, errors.New("/institutions/get_by_id - institution id must be specified")
+	}
+
+	jsonBody, err := json.Marshal(getInstitutionByIDRequest{
+		ID:        id,
+		PublicKey: c.publicKey,
+		Options:   options,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/institutions/get_by_id", jsonBody, &resp)
+	return resp, err
+}
+
+// GetInstitutions returns information for all institutions supported by Plaid.
+// See https://plaid.com/docs/api/#all-institutions.
+func (c *Client) GetInstitutions(count, offset int) (resp GetInstitutionsResponse, err error) {
+	return c.GetInstitutionsWithOptions(count, offset, GetInstitutionsOptions{})
+}
+
+// GetInstitutionsWithOptions returns information for all institutions supported by Plaid.
+// See https://plaid.com/docs/api/#all-institutions.
+func (c *Client) GetInstitutionsWithOptions(
+	count int,
+	offset int,
+	options GetInstitutionsOptions,
+) (resp GetInstitutionsResponse, err error) {
+	if count == 0 {
+		count = 50
+	}
+
+	jsonBody, err := json.Marshal(getInstitutionsRequest{
+		ClientID: c.clientID,
+		Secret:   c.secret,
+		Count:    count,
+		Offset:   offset,
+		Options:  options,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/institutions/get", jsonBody, &resp)
+	return resp, err
+}
+
+// SearchInstitutions returns institutions corresponding to a query string and
+// supported products.
+// See https://plaid.com/docs/api/#institution-search.
+func (c *Client) SearchInstitutions(
+	query string,
+	products []string,
+) (resp SearchInstitutionsResponse, err error) {
+	return c.SearchInstitutionsWithOptions(query, products, SearchInstitutionsOptions{})
+}
+
+// SearchInstitutionsWithOptions returns institutions corresponding to a query string and
+// supported products.
+// See https://plaid.com/docs/api/#institution-search.
+func (c *Client) SearchInstitutionsWithOptions(
+	query string,
+	products []string,
+	options SearchInstitutionsOptions,
+) (resp SearchInstitutionsResponse, err error) {
+	if query == "" {
+		return resp, errors.New("/institutions/search - query must be specified")
+	}
+
+	jsonBody, err := json.Marshal(searchInstitutionsRequest{
+		Query:     query,
+		Products:  products,
+		PublicKey: c.publicKey,
+		Options:   options,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/institutions/search", jsonBody, &resp)
+	return resp, err
+}

--- a/v2/institutions_test.go
+++ b/v2/institutions_test.go
@@ -1,0 +1,82 @@
+package plaid
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetInstitutions(t *testing.T) {
+	for _, options := range []GetInstitutionsOptions{
+		GetInstitutionsOptions{},
+		GetInstitutionsOptions{IncludeOptionalMetadata: true},
+	} {
+		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
+			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, options)
+			assert.Nil(t, err)
+
+			expectedNames := []string{
+				"Amegy Bank of Texas - Personal Banking",
+				"American Express",
+			}
+			outputNames := []string{}
+			for _, inst := range instsResp.Institutions {
+				outputNames = append(outputNames, inst.Name)
+			}
+			sort.Slice(expectedNames, func(i, j int) bool { return expectedNames[i] < expectedNames[j] })
+			sort.Slice(outputNames, func(i, j int) bool { return outputNames[i] < outputNames[j] })
+			assert.Equal(t, expectedNames, outputNames)
+
+			if options.IncludeOptionalMetadata {
+				for _, inst := range instsResp.Institutions {
+					assert.NotEmpty(t, inst.URL)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchInstitutions(t *testing.T) {
+	for _, options := range []SearchInstitutionsOptions{
+		SearchInstitutionsOptions{},
+		SearchInstitutionsOptions{IncludeOptionalMetadata: true},
+	} {
+		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
+			p := []string{"transactions"}
+			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionName, p, options)
+			assert.Nil(t, err)
+			assert.True(t, len(instsResp.Institutions) > 0)
+
+			if options.IncludeOptionalMetadata {
+				for _, inst := range instsResp.Institutions {
+					assert.NotEmpty(t, inst.URL)
+				}
+			}
+		})
+	}
+}
+
+func TestGetInstitutionsByID(t *testing.T) {
+	for _, options := range []GetInstitutionByIDOptions{
+		GetInstitutionByIDOptions{},
+		GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
+		GetInstitutionByIDOptions{IncludeOptionalMetadata: true, IncludeStatus: true},
+	} {
+		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
+			instResp, err := testClient.GetInstitutionByIDWithOptions(sandboxInstitution, options)
+			assert.Nil(t, err)
+			assert.True(t, len(instResp.Institution.Products) > 0)
+
+			if options.IncludeOptionalMetadata {
+				assert.NotEmpty(t, instResp.Institution.URL)
+			}
+
+			if options.IncludeStatus {
+				assert.NotEmpty(t, instResp.Institution.InstitutionStatus)
+				assert.True(t, instResp.Institution.InstitutionStatus.ItemLogins.LastStatusChange.Unix() > 0)
+			}
+		})
+	}
+}

--- a/v2/investment_transactions.go
+++ b/v2/investment_transactions.go
@@ -1,0 +1,102 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type InvestmentTransaction struct {
+	InvestmentTransactionID string `json:"investment_transaction_id"`
+	AccountID               string `json:"account_id"`
+	SecurityID              string `json:"security_id"`
+	CancelTransactionID     string `json:"cancel_transaction_id"`
+
+	Date                   string  `json:"date"`
+	Name                   string  `json:"name"`
+	Quantity               float64 `json:"quantity"`
+	Amount                 float64 `json:"amount"`
+	Price                  float64 `json:"price"`
+	Fees                   float64 `json:"fees"`
+	Type                   string  `json:"type"`
+	ISOCurrencyCode        string  `json:"iso_currency_code"`
+	UnofficialCurrencyCode string  `json:"unofficial_currency_code"`
+}
+
+type GetInvestmentTransactionsResponse struct {
+	APIResponse
+	Item                        Item                    `json:"item"`
+	Accounts                    []Account               `json:"accounts"`
+	InvestmentTransactions      []InvestmentTransaction `json:"investment_transactions"`
+	Securities                  []Security              `json:"securities"`
+	TotalInvestmentTransactions int                     `json:"total_investment_transactions"`
+}
+
+type GetInvestmentTransactionsOptions struct {
+	StartDate  string
+	EndDate    string
+	AccountIDs []string
+	Count      int
+	Offset     int
+}
+
+type getInvestmentTransactionsRequest struct {
+	ClientID    string                                  `json:"client_id"`
+	Secret      string                                  `json:"secret"`
+	AccessToken string                                  `json:"access_token"`
+	StartDate   string                                  `json:"start_date"`
+	EndDate     string                                  `json:"end_date"`
+	Options     getInvestmentTransactionsRequestOptions `json:"options,omitempty"`
+}
+
+type getInvestmentTransactionsRequestOptions struct {
+	AccountIDs []string `json:"account_ids"`
+	Count      int      `json:"count"`
+	Offset     int      `json:"offset"`
+}
+
+// GetInvestmentTransactionsWithOptions retrieves user-authorized investment transaction data for investment-type accounts.
+// See https://plaid.com/docs/api/#investment-transactions.
+func (c *Client) GetInvestmentTransactionsWithOptions(accessToken string, options GetInvestmentTransactionsOptions) (resp GetInvestmentTransactionsResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/investments/transacstions/get - access token must be specified")
+	}
+	if options.StartDate == "" || options.EndDate == "" {
+		return resp, errors.New("/investment/transactions/get - start date and end date must be specified")
+	}
+
+	req := getInvestmentTransactionsRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+		StartDate:   options.StartDate,
+		EndDate:     options.EndDate,
+		Options: getInvestmentTransactionsRequestOptions{
+			Count:  options.Count,
+			Offset: options.Offset,
+		},
+	}
+	if len(options.AccountIDs) > 0 {
+		req.Options.AccountIDs = options.AccountIDs
+	}
+
+	jsonBody, err := json.Marshal(req)
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/investments/transactions/get", jsonBody, &resp)
+	return resp, err
+}
+
+// GetInvestmentTransactions retrieves user-authorized transaction data for investment-type accounts.
+// See https://plaid.com/docs/api/#investment-transactions.
+func (c *Client) GetInvestmentTransactions(accessToken, startDate, endDate string) (resp GetInvestmentTransactionsResponse, err error) {
+	options := GetInvestmentTransactionsOptions{
+		StartDate:  startDate,
+		EndDate:    endDate,
+		AccountIDs: []string{},
+		Count:      100,
+		Offset:     0,
+	}
+	return c.GetInvestmentTransactionsWithOptions(accessToken, options)
+}

--- a/v2/investment_transactions_test.go
+++ b/v2/investment_transactions_test.go
@@ -1,0 +1,30 @@
+package plaid
+
+import (
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetInvestmentTransactions(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, []string{"investments"})
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	startDateString := time.Now().Add(-365 * 24 * time.Hour).Format(iso8601TimeFormat)
+	endDateString := time.Now().Format(iso8601TimeFormat)
+	investmentTransactionsResp, err := testClient.GetInvestmentTransactions(tokenResp.AccessToken, startDateString, endDateString)
+
+	if plaidErr, ok := err.(Error); ok {
+		for ok && plaidErr.ErrorCode == "PRODUCT_NOT_READY" {
+			time.Sleep(5 * time.Second)
+			investmentTransactionsResp, err = testClient.GetInvestmentTransactions(tokenResp.AccessToken, startDateString, endDateString)
+			plaidErr, ok = err.(Error)
+		}
+	}
+
+	assert.Nil(t, err)
+	assert.NotNil(t, investmentTransactionsResp.Accounts)
+	assert.NotNil(t, investmentTransactionsResp.InvestmentTransactions)
+	assert.NotNil(t, investmentTransactionsResp.Securities)
+	assert.NotNil(t, investmentTransactionsResp.Item)
+}

--- a/v2/item.go
+++ b/v2/item.go
@@ -1,0 +1,245 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type Item struct {
+	AvailableProducts []string `json:"available_products"`
+	BilledProducts    []string `json:"billed_products"`
+	Error             Error    `json:"error"`
+	InstitutionID     string   `json:"institution_id"`
+	ItemID            string   `json:"item_id"`
+	Webhook           string   `json:"webhook"`
+}
+
+type getItemRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+}
+
+type GetItemResponse struct {
+	APIResponse
+	Item Item `json:"item"`
+}
+
+type removeItemRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+}
+
+type RemoveItemResponse struct {
+	APIResponse
+	Removed bool `json:"removed"`
+}
+
+type updateItemWebhookRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+	Webhook     string `json:"webhook"`
+}
+
+type UpdateItemWebhookResponse struct {
+	APIResponse
+	Item Item `json:"item"`
+}
+
+type invalidateAccessTokenRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+}
+
+type InvalidateAccessTokenResponse struct {
+	APIResponse
+	NewAccessToken string `json:"new_access_token"`
+}
+
+type updateAccessTokenVersionRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token_v1"`
+}
+
+type UpdateAccessTokenVersionResponse struct {
+	APIResponse
+	NewAccessToken string `json:"access_token"`
+	ItemID         string `json:"item_id"`
+}
+
+type createPublicTokenRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+}
+
+type CreatePublicTokenResponse struct {
+	APIResponse
+	PublicToken string `json:"public_token"`
+}
+
+type exchangePublicTokenRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	PublicToken string `json:"public_token"`
+}
+
+type ExchangePublicTokenResponse struct {
+	APIResponse
+	AccessToken string `json:"access_token"`
+	ItemID      string `json:"item_id"`
+}
+
+// GetItem retrieves an item associated with an access token.
+// See https://plaid.com/docs/api/#retrieve-item.
+func (c *Client) GetItem(accessToken string) (resp GetItemResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/item/get - access token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(getItemRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/item/get", jsonBody, &resp)
+	return resp, err
+}
+
+// RemoveItem removes an item associated with an access token.
+// See https://plaid.com/docs/api/#remove-an-item.
+func (c *Client) RemoveItem(accessToken string) (resp RemoveItemResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/item/remove - access token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(removeItemRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/item/remove", jsonBody, &resp)
+	return resp, err
+}
+
+// UpdateItemWebhook updates the webhook associated with an Item.
+// See https://plaid.com/docs/api/#update-webhook.
+func (c *Client) UpdateItemWebhook(accessToken, webhook string) (resp UpdateItemWebhookResponse, err error) {
+	if accessToken == "" || webhook == "" {
+		return resp, errors.New("/item/webhook/update - access token and webhook must be specified")
+	}
+
+	jsonBody, err := json.Marshal(updateItemWebhookRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+		Webhook:     webhook,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/item/webhook/update", jsonBody, &resp)
+	return resp, err
+}
+
+// InvalidateAccessToken invalidates and rotates an access token.
+// See https://plaid.com/docs/api/#rotate-access-token.
+func (c *Client) InvalidateAccessToken(accessToken string) (resp InvalidateAccessTokenResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/item/access_token/invalidate - access token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(invalidateAccessTokenRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/item/access_token/invalidate", jsonBody, &resp)
+	return resp, err
+}
+
+// UpdateAccessTokenVersion generates an updated access token associated with
+// the legacy version of Plaid's API.
+// See https://plaid.com/docs/api/#update-access-token-version.
+func (c *Client) UpdateAccessTokenVersion(accessToken string) (resp UpdateAccessTokenVersionResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/item/access_token/update_version - access token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(updateAccessTokenVersionRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/item/access_token/update_version", jsonBody, &resp)
+	return resp, err
+}
+
+// CreatePublicToken generates a one-time use public token which expires in
+// 30 minutes to update an Item.
+// See https://plaid.com/docs/api/#creating-public-tokens.
+func (c *Client) CreatePublicToken(accessToken string) (resp CreatePublicTokenResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/item/public_token/create - access token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(createPublicTokenRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/item/public_token/create", jsonBody, &resp)
+	return resp, err
+}
+
+// ExchangePublicToken exchanges a public token for an access token.
+// See https://plaid.com/docs/api/#exchange-token-flow.
+func (c *Client) ExchangePublicToken(publicToken string) (resp ExchangePublicTokenResponse, err error) {
+	if publicToken == "" {
+		return resp, errors.New("/item/public_token/exchange - public token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(exchangePublicTokenRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		PublicToken: publicToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/item/public_token/exchange", jsonBody, &resp)
+	return resp, err
+}

--- a/v2/item_test.go
+++ b/v2/item_test.go
@@ -1,0 +1,80 @@
+package plaid
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func randomHex(n int) (string, error) {
+	bytes := make([]byte, n)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+func TestGetItem(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	itemResp, err := testClient.GetItem(tokenResp.AccessToken)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, itemResp.Item)
+}
+
+func TestRemoveItem(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	itemResp, err := testClient.RemoveItem(tokenResp.AccessToken)
+
+	assert.Nil(t, err)
+	assert.True(t, itemResp.Removed)
+}
+
+func TestUpdateItemWebhook(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	itemResp, err := testClient.UpdateItemWebhook(tokenResp.AccessToken, "https://plaid.com/webhook-test")
+
+	assert.Nil(t, err)
+	assert.NotNil(t, itemResp.Item)
+	assert.Equal(t, itemResp.Item.Webhook, "https://plaid.com/webhook-test")
+}
+
+func TestInvalidateAccessToken(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	newTokenResp, err := testClient.InvalidateAccessToken(tokenResp.AccessToken)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, newTokenResp.NewAccessToken)
+}
+
+func TestUpdateAccessTokenVersion(t *testing.T) {
+	invalidToken, _ := randomHex(80)
+	newTokenResp, err := testClient.InvalidateAccessToken(invalidToken)
+	assert.NotNil(t, err)
+	assert.True(t, newTokenResp.NewAccessToken == "")
+}
+
+func TestCreatePublicToken(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	publicTokenResp, err := testClient.CreatePublicToken(tokenResp.AccessToken)
+
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(publicTokenResp.PublicToken, "public-sandbox"))
+}
+
+func TestExchangePublicToken(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(tokenResp.AccessToken, "access-sandbox"))
+	assert.NotNil(t, tokenResp.ItemID)
+}

--- a/v2/liabilities.go
+++ b/v2/liabilities.go
@@ -1,0 +1,130 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// StudentLoanLiability contains student loan liability data.
+type StudentLoanLiability struct {
+	AccountID                  string                     `json:"account_id"`
+	AccountNumber              string                     `json:"account_number"`
+	DisbursementDates          []string                   `json:"disbursement_dates"`
+	ExpectedPayoffDate         string                     `json:"expected_payoff_date"`
+	Guarantor                  string                     `json:"guarantor"`
+	InterestRatePercentage     float64                    `json:"interest_rate_percentage"`
+	IsOverdue                  bool                       `json:"is_overdue"`
+	LastPaymentAmount          float64                    `json:"last_payment_amount"`
+	LastPaymentDate            string                     `json:"last_payment_date"`
+	LastStatementBalance       float64                    `json:"last_statement_balance"`
+	LastStatementIssueDate     string                     `json:"last_statement_issue_date"`
+	LoanName                   string                     `json:"loan_name"`
+	LoanStatus                 StudentLoanStatus          `json:"loan_status"`
+	MinimumPaymentAmount       float64                    `json:"minimum_payment_amount"`
+	NextPaymentDueDate         string                     `json:"next_payment_due_date"`
+	OriginationDate            string                     `json:"origination_date"`
+	OriginationPrincipalAmount float64                    `json:"origination_principal_amount"`
+	OutstandingInterestAmount  float64                    `json:"outstanding_interest_amount"`
+	PaymentReferenceNumber     string                     `json:"payment_reference_number"`
+	PSLFStatus                 PSLFStatus                 `json:"pslf_status"`
+	RepaymentPlan              StudentLoanRepaymentPlan   `json:"repayment_plan"`
+	SequenceNumber             string                     `json:"sequence_number"`
+	ServicerAddress            StudentLoanServicerAddress `json:"servicer_address"`
+	YTDInterestPaid            float64                    `json:"ytd_interest_paid"`
+	YTDPrincipalPaid           float64                    `json:"ytd_principal_paid"`
+}
+
+// PSLFStatus contains information about the student's eligibility in the
+// Public Service Loan Forgiveness program.
+type PSLFStatus struct {
+	EstimatedEligibilityDate string `json:"estimated_eligibility_date"`
+	PaymentsMade             int64  `json:"payments_made"`
+	PaymentsRemaining        int64  `json:"payments_remaining"`
+}
+
+// StudentLoanServicerAddress is the address of the servicer.
+type StudentLoanServicerAddress struct {
+	City       string `json:"city"`
+	Country    string `json:"country"`
+	PostalCode string `json:"postal_code"`
+	Region     string `json:"region"`
+	Street     string `json:"street"`
+}
+
+// StudentLoanStatus contains details about the status of the student loan.
+type StudentLoanStatus struct {
+	Type    string `json:"type"`
+	EndDate string `json:"end_date"`
+}
+
+// StudentLoanRepaymentPlan contains details about the repayment plan of the
+// loan.
+type StudentLoanRepaymentPlan struct {
+	Type        string `json:"type"`
+	Description string `json:"description"`
+}
+
+type getLiabilitiesRequestOptions struct {
+	AccountIDs []string `json:"account_ids,omitempty"`
+}
+
+type getLiabilitiesRequest struct {
+	ClientID    string                       `json:"client_id"`
+	Secret      string                       `json:"secret"`
+	AccessToken string                       `json:"access_token"`
+	Options     getLiabilitiesRequestOptions `json:"options,omitempty"`
+}
+
+// GetLiabilitiesResponse is the response from /liabilities/get.
+type GetLiabilitiesResponse struct {
+	APIResponse
+	Accounts    []Account `json:"accounts"`
+	Item        Item      `json:"item"`
+	Liabilities struct {
+		Student []StudentLoanLiability `json:"student"`
+	} `json:"liabilities"`
+}
+
+// GetLiabilitiesOptions contains options for /liabilities/get.
+type GetLiabilitiesOptions struct {
+	// AccountIDs is used to filter accounts included in the response. A nil or
+	// zero-length slice does not result in any filter being applied.
+	AccountIDs []string
+}
+
+// GetLiabilitiesWithOptions retrieves liability data. See
+// https://plaid.com/docs/api/#liabilities.
+func (c *Client) GetLiabilitiesWithOptions(
+	accessToken string,
+	options GetLiabilitiesOptions,
+) (resp GetLiabilitiesResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/liabilities/get - access token must be specified")
+	}
+
+	req := getLiabilitiesRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+		Options:     getLiabilitiesRequestOptions{},
+	}
+	if len(options.AccountIDs) > 0 {
+		req.Options.AccountIDs = options.AccountIDs
+	}
+
+	jsonBody, err := json.Marshal(req)
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/liabilities/get", jsonBody, &resp)
+	return resp, err
+}
+
+// GetLiabilities retrieves liability data. See
+// https://plaid.com/docs/api/#liabilities.
+func (c *Client) GetLiabilities(accessToken string) (resp GetLiabilitiesResponse, err error) {
+	return c.GetLiabilitiesWithOptions(accessToken, GetLiabilitiesOptions{
+		AccountIDs: []string{},
+	})
+}

--- a/v2/liabilities_test.go
+++ b/v2/liabilities_test.go
@@ -1,0 +1,27 @@
+package plaid
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetLiabilities(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, []string{"liabilities"})
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	liabilitiesResp, err := testClient.GetLiabilities(tokenResp.AccessToken)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, liabilitiesResp.Accounts)
+	assert.NotNil(t, liabilitiesResp.Item)
+	assert.NotNil(t, liabilitiesResp.Liabilities)
+	assert.Len(t, liabilitiesResp.Liabilities.Student, 1)
+
+	accountID := liabilitiesResp.Accounts[7].AccountID
+	liabilitiesResp, err = testClient.GetLiabilitiesWithOptions(tokenResp.AccessToken, GetLiabilitiesOptions{
+		AccountIDs: []string{accountID},
+	})
+	assert.Nil(t, err)
+	assert.Len(t, liabilitiesResp.Accounts, 1)
+	assert.Len(t, liabilitiesResp.Liabilities.Student, 1)
+}

--- a/v2/plaid.go
+++ b/v2/plaid.go
@@ -1,0 +1,117 @@
+package plaid
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+
+const (
+	// APIVersion holds the latest version of the Plaid API
+	APIVersion = "2019-05-29"
+
+	ClientVersion = "2.0.1"
+)
+
+// Client holds information required to interact with the Plaid API.
+// Note: Client is only exported for method documentation purposes.
+// Instances should only be created through the 'NewClient' function.
+//
+// See https://github.com/golang/go/issues/7823.
+type Client struct {
+	clientID    string
+	secret      string
+	publicKey   string
+	environment Environment
+	httpClient  *http.Client
+}
+
+type ClientOptions struct {
+	ClientID    string
+	Secret      string
+	PublicKey   string
+	Environment Environment
+	HTTPClient  *http.Client
+}
+
+// NewClient instantiates a Client associated with a client id, secret and environment.
+func NewClient(options ClientOptions) (client *Client, err error) {
+	if !options.Environment.Valid() {
+		return nil, errors.New("Invalid environment specified: " + string(options.Environment))
+	}
+
+	if options.HTTPClient == nil {
+		options.HTTPClient = &http.Client{}
+	}
+
+	return &Client{
+		clientID:    options.ClientID,
+		secret:      options.Secret,
+		publicKey:   options.PublicKey,
+		environment: options.Environment,
+		httpClient:  options.HTTPClient,
+	}, nil
+}
+
+func (c *Client) Call(endpoint string, body []byte, v interface{}) error {
+	req, err := c.newRequest(endpoint, bytes.NewReader(body), v)
+	if err != nil {
+		return err
+	}
+
+	return c.do(req, v)
+}
+
+// newRequest is used by Call to generate a http.Request with appropriate headers.
+func (c *Client) newRequest(endpoint string, body io.Reader, v interface{}) (*http.Request, error) {
+	if !strings.HasPrefix(endpoint, "/") {
+		endpoint = "/" + endpoint
+	}
+
+	req, err := http.NewRequest("POST", "https://"+string(c.environment)+endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", "Plaid Go v"+ClientVersion)
+
+	// Add header for Plaid API version
+	req.Header.Add("Plaid-Version", APIVersion)
+
+	return req, nil
+}
+
+// do is used by Call to execute an http.Request and parse its response.
+// Also handles parsing of the plaid error format.
+func (c *Client) do(req *http.Request, v interface{}) error {
+	res, err := c.httpClient.Do(req)
+
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	resBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	// Successful response
+	if res.StatusCode == 200 {
+		return json.Unmarshal(resBody, v)
+	}
+
+	// Attempt to unmarshal into Plaid error format
+	var plaidErr Error
+	if err = json.Unmarshal(resBody, &plaidErr); err != nil {
+		return err
+	}
+	plaidErr.StatusCode = res.StatusCode
+	return plaidErr
+}

--- a/v2/processor.go
+++ b/v2/processor.go
@@ -1,0 +1,91 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type createProcessorTokenRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+	AccountID   string `json:"account_id"`
+}
+
+type createProcessorTokenResponse struct {
+	APIResponse
+	ProcessorToken string `json:"processor_token"`
+}
+
+type CreateApexTokenResponse createProcessorTokenResponse
+type CreateDwollaTokenResponse createProcessorTokenResponse
+type CreateOcrolusTokenResponse createProcessorTokenResponse
+
+type createStripeTokenRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+	AccountID   string `json:"account_id"`
+}
+
+type CreateStripeTokenResponse struct {
+	APIResponse
+	StripeBankAccountToken string `json:"stripe_bank_account_token"`
+}
+
+func (c *Client) createProcessorToken(apiEndpoint, accessToken, accountID string) (resp createProcessorTokenResponse, err error) {
+	if accessToken == "" || accountID == "" {
+		return resp, errors.New(apiEndpoint + " - access token and account ID must be specified")
+	}
+
+	jsonBody, err := json.Marshal(createProcessorTokenRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+		AccountID:   accountID,
+	})
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call(apiEndpoint, jsonBody, &resp)
+	return resp, err
+}
+
+// CreateApexToken is used to create a new Apex processor token.
+func (c *Client) CreateApexToken(accessToken, accountID string) (resp CreateApexTokenResponse, err error) {
+	response, err := c.createProcessorToken("/processor/apex/processor_token/create", accessToken, accountID)
+	return CreateApexTokenResponse(response), err
+}
+
+// CreateDwollaToken is used to create a new Dwolla processor token.
+func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp CreateDwollaTokenResponse, err error) {
+	response, err := c.createProcessorToken("/processor/dwolla/processor_token/create", accessToken, accountID)
+	return CreateDwollaTokenResponse(response), err
+}
+
+// CreateOcrolusToken is used to create a new Ocrolus processor token.
+func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp CreateOcrolusTokenResponse, err error) {
+	response, err := c.createProcessorToken("/processor/ocrolus/processor_token/create", accessToken, accountID)
+	return CreateOcrolusTokenResponse(response), err
+}
+
+// CreateStripeToken is used to create a new Stripe bank account token.
+func (c *Client) CreateStripeToken(accessToken, accountID string) (resp CreateStripeTokenResponse, err error) {
+	if accessToken == "" || accountID == "" {
+		return resp, errors.New("/processor/stripe/bank_account_token/create - access token and account ID must be specified")
+	}
+
+	jsonBody, err := json.Marshal(createStripeTokenRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+		AccountID:   accountID,
+	})
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/processor/stripe/bank_account_token/create", jsonBody, &resp)
+	return resp, err
+}

--- a/v2/processor_test.go
+++ b/v2/processor_test.go
@@ -1,0 +1,91 @@
+package plaid
+
+import (
+	"strings"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestCreateApexToken(t *testing.T) {
+	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	assert.Nil(t, err)
+
+	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	assert.Nil(t, err)
+
+	// get test account
+	options := GetAccountsOptions{
+		AccountIDs: []string{},
+	}
+	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	assert.Nil(t, err)
+	accountID := accountsResp.Accounts[0].AccountID
+
+	apexTokenResp, err := testClient.CreateApexToken(tokenResp.AccessToken, accountID)
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(apexTokenResp.ProcessorToken, "processor-sandbox-"))
+
+}
+
+func TestCreateDwollaToken(t *testing.T) {
+	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	assert.Nil(t, err)
+
+	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	assert.Nil(t, err)
+
+	// get test account
+	options := GetAccountsOptions{
+		AccountIDs: []string{},
+	}
+	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	assert.Nil(t, err)
+	accountID := accountsResp.Accounts[0].AccountID
+
+	dwollaTokenResp, err := testClient.CreateDwollaToken(tokenResp.AccessToken, accountID)
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(dwollaTokenResp.ProcessorToken, "processor-sandbox-"))
+}
+
+func TestCreateOcrolusToken(t *testing.T) {
+	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	assert.Nil(t, err)
+
+	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	assert.Nil(t, err)
+
+	// get test account
+	options := GetAccountsOptions{
+		AccountIDs: []string{},
+	}
+	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	assert.Nil(t, err)
+	accountID := accountsResp.Accounts[0].AccountID
+
+	ocrolusTokenResp, err := testClient.CreateOcrolusToken(tokenResp.AccessToken, accountID)
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(ocrolusTokenResp.ProcessorToken, "processor-sandbox-"))
+}
+
+func TestCreateStripeToken(t *testing.T) {
+	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	assert.Nil(t, err)
+
+	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	assert.Nil(t, err)
+
+	// get test account
+	options := GetAccountsOptions{
+		AccountIDs: []string{},
+	}
+	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
+	assert.Nil(t, err)
+	accountID := accountsResp.Accounts[0].AccountID
+
+	t.Skip("CircleCI is not setup to work with stripe")
+
+	stripeTokenResp, err := testClient.CreateStripeToken(tokenResp.AccessToken, accountID)
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(stripeTokenResp.StripeBankAccountToken, "btok_"))
+}

--- a/v2/sandbox.go
+++ b/v2/sandbox.go
@@ -1,0 +1,66 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type createSandboxPublicTokenRequest struct {
+	InstitutionID   string   `json:"institution_id"`
+	InitialProducts []string `json:"initial_products"`
+	PublicKey       string   `json:"public_key"`
+}
+
+type CreateSandboxPublicTokenResponse struct {
+	APIResponse
+	PublicToken string `json:"public_token"`
+}
+
+type resetSandboxItemRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	AccessToken string `json:"access_token"`
+}
+
+type ResetSandboxItemResponse struct {
+	APIResponse
+	ResetLogin bool `json:"reset_login"`
+}
+
+func (c *Client) CreateSandboxPublicToken(institutionID string, initialProducts []string) (resp CreateSandboxPublicTokenResponse, err error) {
+	if institutionID == "" || len(initialProducts) == 0 {
+		return resp, errors.New("/sandbox/public_token/create - institution id and initial products must be specified")
+	}
+
+	jsonBody, err := json.Marshal(createSandboxPublicTokenRequest{
+		InstitutionID:   institutionID,
+		InitialProducts: initialProducts,
+		PublicKey:       c.publicKey,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/sandbox/public_token/create", jsonBody, &resp)
+	return resp, err
+}
+
+func (c *Client) ResetSandboxItem(accessToken string) (resp ResetSandboxItemResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/sandbox/item/reset_login - access token must be specified")
+	}
+
+	jsonBody, err := json.Marshal(resetSandboxItemRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/sandbox/item/reset_login", jsonBody, &resp)
+	return resp, err
+}

--- a/v2/sandbox_test.go
+++ b/v2/sandbox_test.go
@@ -1,0 +1,24 @@
+package plaid
+
+import (
+	"strings"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestCreateSandboxPublicToken(t *testing.T) {
+	sandboxResp, err := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(sandboxResp.PublicToken, "public-sandbox"))
+}
+
+func TestResetSandboxItem(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	resetResp, err := testClient.ResetSandboxItem(tokenResp.AccessToken)
+
+	assert.Nil(t, err)
+	assert.True(t, resetResp.ResetLogin)
+}

--- a/v2/transactions.go
+++ b/v2/transactions.go
@@ -1,0 +1,125 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type Transaction struct {
+	AccountID              string   `json:"account_id"`
+	Amount                 float64  `json:"amount"`
+	ISOCurrencyCode        string   `json:"iso_currency_code"`
+	UnofficialCurrencyCode string   `json:"unofficial_currency_code"`
+	Category               []string `json:"category"`
+	CategoryID             string   `json:"category_id"`
+	Date                   string   `json:"date"`
+
+	Location Location `json:"location"`
+
+	Name string `json:"name"`
+
+	PaymentMeta PaymentMeta `json:"payment_meta"`
+
+	Pending              bool   `json:"pending"`
+	PendingTransactionID string `json:"pending_transaction_id"`
+	AccountOwner         string `json:"account_owner"`
+	ID                   string `json:"transaction_id"`
+	Type                 string `json:"transaction_type"`
+}
+
+type Location struct {
+	Address     string  `json:"address"`
+	City        string  `json:"city"`
+	Lat         float64 `json:"lat"`
+	Lon         float64 `json:"lon"`
+	Region      string  `json:"region"`
+	StoreNumber string  `json:"store_number"`
+	PostalCode  string  `json:"postal_code"`
+	Country     string  `json:"country"`
+}
+
+type PaymentMeta struct {
+	ByOrderOf        string `json:"by_order_of"`
+	Payee            string `json:"payee"`
+	Payer            string `json:"payer"`
+	PaymentMethod    string `json:"payment_method"`
+	PaymentProcessor string `json:"payment_processor"`
+	PPDID            string `json:"ppd_id"`
+	Reason           string `json:"reason"`
+	ReferenceNumber  string `json:"reference_number"`
+}
+
+type getTransactionsRequestOptions struct {
+	AccountIDs []string `json:"account_ids"`
+	Count      int      `json:"count"`
+	Offset     int      `json:"offset"`
+}
+
+type getTransactionsRequest struct {
+	ClientID    string                        `json:"client_id"`
+	Secret      string                        `json:"secret"`
+	AccessToken string                        `json:"access_token"`
+	StartDate   string                        `json:"start_date"`
+	EndDate     string                        `json:"end_date"`
+	Options     getTransactionsRequestOptions `json:"options,omitempty"`
+}
+
+type GetTransactionsResponse struct {
+	APIResponse
+	Accounts          []Account     `json:"accounts"`
+	Item              Item          `json:"item"`
+	Transactions      []Transaction `json:"transactions"`
+	TotalTransactions int           `json:"total_transactions"`
+}
+
+type GetTransactionsOptions struct {
+	StartDate  string
+	EndDate    string
+	AccountIDs []string
+	Count      int
+	Offset     int
+}
+
+// GetTransactionsWithOptions retrieves user-authorized transaction data for credit and depository-type accounts.
+// See https://plaid.com/docs/api/#transactions.
+func (c *Client) GetTransactionsWithOptions(accessToken string, options GetTransactionsOptions) (resp GetTransactionsResponse, err error) {
+	if options.StartDate == "" || options.EndDate == "" {
+		return resp, errors.New("/transactions/get - start date and end date must be specified")
+	}
+
+	req := getTransactionsRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+		StartDate:   options.StartDate,
+		EndDate:     options.EndDate,
+		Options: getTransactionsRequestOptions{
+			Count:  options.Count,
+			Offset: options.Offset,
+		},
+	}
+	if len(options.AccountIDs) > 0 {
+		req.Options.AccountIDs = options.AccountIDs
+	}
+
+	jsonBody, err := json.Marshal(req)
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/transactions/get", jsonBody, &resp)
+	return resp, err
+}
+
+// GetTransactions retrieves user-authorized transaction data for credit and depository-type accounts.
+// See https://plaid.com/docs/api/#transactions.
+func (c *Client) GetTransactions(accessToken, startDate, endDate string) (resp GetTransactionsResponse, err error) {
+	options := GetTransactionsOptions{
+		StartDate:  startDate,
+		EndDate:    endDate,
+		AccountIDs: []string{},
+		Count:      100,
+		Offset:     0,
+	}
+	return c.GetTransactionsWithOptions(accessToken, options)
+}

--- a/v2/transactions_test.go
+++ b/v2/transactions_test.go
@@ -1,0 +1,57 @@
+package plaid
+
+import (
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+const iso8601TimeFormat = "2006-01-02"
+
+func TestGetTransactions(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	startDate := time.Now().Add(-365 * 24 * time.Hour).Format(iso8601TimeFormat)
+	endDate := time.Now().Format(iso8601TimeFormat)
+	transactionsResp, err := testClient.GetTransactions(tokenResp.AccessToken, startDate, endDate)
+
+	if plaidErr, ok := err.(Error); ok {
+		for ok && plaidErr.ErrorCode == "PRODUCT_NOT_READY" {
+			time.Sleep(5 * time.Second)
+			transactionsResp, err = testClient.GetTransactions(tokenResp.AccessToken, startDate, endDate)
+			plaidErr, ok = err.(Error)
+		}
+	}
+
+	assert.Nil(t, err)
+	assert.NotNil(t, transactionsResp.Accounts)
+	assert.NotNil(t, transactionsResp.Transactions)
+}
+
+func TestGetTransactionsWithOptions(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+
+	startDate := time.Now().Add(-365 * 24 * time.Hour).Format(iso8601TimeFormat)
+	endDate := time.Now().Format(iso8601TimeFormat)
+	options := GetTransactionsOptions{
+		StartDate:  startDate,
+		EndDate:    endDate,
+		AccountIDs: []string{},
+		Count:      2,
+		Offset:     1,
+	}
+	transactionsResp, err := testClient.GetTransactionsWithOptions(tokenResp.AccessToken, options)
+
+	if plaidErr, ok := err.(Error); ok {
+		for ok && plaidErr.ErrorCode == "PRODUCT_NOT_READY" {
+			time.Sleep(5 * time.Second)
+			transactionsResp, err = testClient.GetTransactionsWithOptions(tokenResp.AccessToken, options)
+			plaidErr, ok = err.(Error)
+		}
+	}
+
+	assert.Nil(t, err)
+	assert.NotNil(t, transactionsResp.Transactions)
+}


### PR DESCRIPTION
Hello

I'm looking at Plaid for a client and the system uses Go modules; it would be nice if this package where modularised.  It looks like you might have had a look at this previously and deferred completion.

I _think_ the best way to go about this would be as per this PR (although I have initialised to module with a namespace matching my forked repo so obviously that would be different) which in a nutshell is start at V2 and create V2 folder as per the module spec. https://blog.golang.org/v2-go-modules.  I haven't solved the requirement to inject the client version into the package so it can be added as a header on all requests. Probably a little code gen on the release CI build would be a good solution?

Kind Regards
Myles