### PR TITLE
Add generic processor token method

### DIFF
--- a/internal/version_autogenerated.go
+++ b/internal/version_autogenerated.go
@@ -4,5 +4,5 @@ package internal
 
 const (
 	// Version is the current version of the plaid-go library
-	Version = "2.2.0"
+	Version = "2.3.0"
 )

--- a/main.go
+++ b/main.go
@@ -84,4 +84,37 @@ func main() {
 		handleError(err)
 	}
 	fmt.Println("Number of transactions:", len(transactionsResp.Transactions))
+
+	// POST /payment_initiation/recipient/create
+	paymentRecipientCreateResp, err := client.CreatePaymentRecipient("John Doe", "GB33BUKB20201555555555", plaid.PaymentRecipientAddress{
+		Street:     []string{"Street Name 999"},
+		City:       "City",
+		PostalCode: "99999",
+		Country:    "GB",
+	})
+	handleError(err)
+	fmt.Println("Recipient ID:", paymentRecipientCreateResp.RecipientID)
+
+	// POST /payment_initiation/recipient/get
+	paymentRecipientGetResp, err := client.GetPaymentRecipient(paymentRecipientCreateResp.RecipientID)
+	handleError(err)
+	fmt.Println("Recipient get response:", paymentRecipientGetResp)
+
+	// POST /payment_initiation/payment/create
+	paymentCreateResp, err := client.CreatePayment(paymentRecipientCreateResp.RecipientID, "TestPayment", plaid.PaymentAmount{
+		Currency: "GBP",
+		Value:    100.0,
+	})
+	handleError(err)
+	fmt.Println("Payment ID:", paymentCreateResp.PaymentID)
+
+	// POST /payment_initiation/payment/token/create
+	paymentTokenCreateResp, err := client.CreatePaymentToken(paymentCreateResp.PaymentID)
+	handleError(err)
+	fmt.Println("Payment Token:", paymentTokenCreateResp.PaymentToken)
+
+	// POST /payment_initiation/payment/get
+	paymentGetResp, err := client.GetPayment(paymentCreateResp.PaymentID)
+	handleError(err)
+	fmt.Println("Payment get response:", paymentGetResp)
 }

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -2,7 +2,6 @@ package plaid
 
 import (
 	"fmt"
-	"sort"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -17,17 +16,10 @@ func TestGetInstitutions(t *testing.T) {
 			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, options)
 			assert.Nil(t, err)
 
-			expectedNames := []string{
-				"Amegy Bank of Texas - Personal Banking",
-				"American Express",
-			}
-			outputNames := []string{}
+			assert.Len(t, instsResp.Institutions, 2)
 			for _, inst := range instsResp.Institutions {
-				outputNames = append(outputNames, inst.Name)
+				assert.NotEmpty(t, inst.Name)
 			}
-			sort.Slice(expectedNames, func(i, j int) bool { return expectedNames[i] < expectedNames[j] })
-			sort.Slice(outputNames, func(i, j int) bool { return outputNames[i] < outputNames[j] })
-			assert.Equal(t, expectedNames, outputNames)
 
 			if options.IncludeOptionalMetadata {
 				for _, inst := range instsResp.Institutions {
@@ -62,7 +54,6 @@ func TestGetInstitutionsByID(t *testing.T) {
 	for _, options := range []GetInstitutionByIDOptions{
 		GetInstitutionByIDOptions{},
 		GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
-		GetInstitutionByIDOptions{IncludeOptionalMetadata: true, IncludeStatus: true},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			instResp, err := testClient.GetInstitutionByIDWithOptions(sandboxInstitution, options)
@@ -71,11 +62,6 @@ func TestGetInstitutionsByID(t *testing.T) {
 
 			if options.IncludeOptionalMetadata {
 				assert.NotEmpty(t, instResp.Institution.URL)
-			}
-
-			if options.IncludeStatus {
-				assert.NotEmpty(t, instResp.Institution.InstitutionStatus)
-				assert.True(t, instResp.Institution.InstitutionStatus.ItemLogins.LastStatusChange.Unix() > 0)
 			}
 		})
 	}

--- a/plaid/item.go
+++ b/plaid/item.go
@@ -7,13 +7,14 @@ import (
 )
 
 type Item struct {
-	AvailableProducts []string   `json:"available_products"`
-	BilledProducts    []string   `json:"billed_products"`
-	Error             Error      `json:"error"`
-	InstitutionID     string     `json:"institution_id"`
-	ItemID            string     `json:"item_id"`
-	Webhook           string     `json:"webhook"`
-	Status            ItemStatus `json:"status"`
+	AvailableProducts     []string   `json:"available_products"`
+	BilledProducts        []string   `json:"billed_products"`
+	Error                 Error      `json:"error"`
+	InstitutionID         string     `json:"institution_id"`
+	ItemID                string     `json:"item_id"`
+	Webhook               string     `json:"webhook"`
+	Status                ItemStatus `json:"status"`
+	ConsentExpirationTime time.Time  `json:"consent_expiration_time"`
 }
 
 type ItemStatus struct {

--- a/plaid/item.go
+++ b/plaid/item.go
@@ -7,14 +7,13 @@ import (
 )
 
 type Item struct {
-	AvailableProducts     []string   `json:"available_products"`
-	BilledProducts        []string   `json:"billed_products"`
-	Error                 Error      `json:"error"`
-	InstitutionID         string     `json:"institution_id"`
-	ItemID                string     `json:"item_id"`
-	Webhook               string     `json:"webhook"`
-	Status                ItemStatus `json:"status"`
-	ConsentExpirationTime time.Time  `json:"consent_expiration_time"`
+	AvailableProducts     []string  `json:"available_products"`
+	BilledProducts        []string  `json:"billed_products"`
+	Error                 Error     `json:"error"`
+	InstitutionID         string    `json:"institution_id"`
+	ItemID                string    `json:"item_id"`
+	Webhook               string    `json:"webhook"`
+	ConsentExpirationTime time.Time `json:"consent_expiration_time"`
 }
 
 type ItemStatus struct {
@@ -41,7 +40,8 @@ type getItemRequest struct {
 
 type GetItemResponse struct {
 	APIResponse
-	Item Item `json:"item"`
+	Item   Item       `json:"item"`
+	Status ItemStatus `json:"status"`
 }
 
 type removeItemRequest struct {

--- a/plaid/item.go
+++ b/plaid/item.go
@@ -3,15 +3,33 @@ package plaid
 import (
 	"encoding/json"
 	"errors"
+	"time"
 )
 
 type Item struct {
-	AvailableProducts []string `json:"available_products"`
-	BilledProducts    []string `json:"billed_products"`
-	Error             Error    `json:"error"`
-	InstitutionID     string   `json:"institution_id"`
-	ItemID            string   `json:"item_id"`
-	Webhook           string   `json:"webhook"`
+	AvailableProducts []string   `json:"available_products"`
+	BilledProducts    []string   `json:"billed_products"`
+	Error             Error      `json:"error"`
+	InstitutionID     string     `json:"institution_id"`
+	ItemID            string     `json:"item_id"`
+	Webhook           string     `json:"webhook"`
+	Status            ItemStatus `json:"status"`
+}
+
+type ItemStatus struct {
+	Transactions ProductStatus `json:"transactions,omitempty"`
+	Investments  ProductStatus `json:"investments,omitempty"`
+	LastWebhook  WebhookStatus `json:"last_webhook,omitempty"`
+}
+
+type ProductStatus struct {
+	LastFailedUpdate     time.Time `json:"last_failed_update,omitempty"`
+	LastSuccessfulUpdate time.Time `json:"last_successful_update,omitempty"`
+}
+
+type WebhookStatus struct {
+	SentAt   time.Time `json:"sent_at,omitempty"`
+	CodeSent string    `json:"code_sent,omitempty"`
 }
 
 type getItemRequest struct {

--- a/plaid/item_test.go
+++ b/plaid/item_test.go
@@ -24,6 +24,7 @@ func TestGetItem(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, itemResp.Item)
+	assert.NotEmpty(t, itemResp.Status)
 }
 
 func TestRemoveItem(t *testing.T) {

--- a/plaid/payment.go
+++ b/plaid/payment.go
@@ -1,0 +1,243 @@
+package plaid
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type PaymentRecipientAddress struct {
+	// Street is an array with length in range [1, 4].
+	Street     []string `json:"street"`
+	City       string   `json:"city"`
+	PostalCode string   `json:"postal_code"`
+	// Country is an uppercase ISO 3166-1 alpha-2 country code.
+	Country string `json:"country"`
+}
+
+type createPaymentRecipientRequest struct {
+	ClientID string                  `json:"client_id"`
+	Secret   string                  `json:"secret"`
+	Name     string                  `json:"name"`
+	IBAN     string                  `json:"iban"`
+	Address  PaymentRecipientAddress `json:"address"`
+}
+
+type CreatePaymentRecipientResponse struct {
+	APIResponse
+	RecipientID string `json:"recipient_id"`
+}
+
+func (c *Client) CreatePaymentRecipient(
+	name string,
+	iban string,
+	address PaymentRecipientAddress,
+) (resp CreatePaymentRecipientResponse, err error) {
+	jsonBody, err := json.Marshal(createPaymentRecipientRequest{
+		ClientID: c.clientID,
+		Secret:   c.secret,
+		Name:     name,
+		IBAN:     iban,
+		Address:  address,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/payment_initiation/recipient/create", jsonBody, &resp)
+	return resp, err
+}
+
+type getPaymentRecipientRequest struct {
+	ClientID    string `json:"client_id"`
+	Secret      string `json:"secret"`
+	RecipientID string `json:"recipient_id"`
+}
+
+type Recipient struct {
+	RecipientID string                  `json:"recipient_id"`
+	Name        string                  `json:"name"`
+	IBAN        string                  `json:"iban"`
+	Address     PaymentRecipientAddress `json:"address"`
+}
+
+type GetPaymentRecipientResponse struct {
+	APIResponse
+	Recipient
+}
+
+func (c *Client) GetPaymentRecipient(recipientID string) (resp GetPaymentRecipientResponse, err error) {
+	jsonBody, err := json.Marshal(getPaymentRecipientRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		RecipientID: recipientID,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/payment_initiation/recipient/get", jsonBody, &resp)
+	return resp, err
+}
+
+type listPaymentRecipientsRequest struct {
+	ClientID string `json:"client_id"`
+	Secret   string `json:"secret"`
+}
+
+type ListPaymentRecipientsResponse struct {
+	APIResponse
+	Recipients []Recipient `json:"recipients"`
+}
+
+func (c *Client) ListPaymentRecipients() (resp ListPaymentRecipientsResponse, err error) {
+	jsonBody, err := json.Marshal(listPaymentRecipientsRequest{
+		ClientID: c.clientID,
+		Secret:   c.secret,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/payment_initiation/recipient/list", jsonBody, &resp)
+	return resp, err
+}
+
+type PaymentAmount struct {
+	Currency string  `json:"currency"`
+	Value    float64 `json:"value"`
+}
+
+type createPaymentRequest struct {
+	ClientID    string        `json:"client_id"`
+	Secret      string        `json:"secret"`
+	RecipientID string        `json:"recipient_id"`
+	Reference   string        `json:"reference"`
+	Amount      PaymentAmount `json:"amount"`
+}
+
+type CreatePaymentResponse struct {
+	APIResponse
+	PaymentID string `json:"payment_id"`
+	Status    string `json:"status"`
+}
+
+func (c *Client) CreatePayment(
+	recipientID string,
+	reference string,
+	amount PaymentAmount,
+) (resp CreatePaymentResponse, err error) {
+	jsonBody, err := json.Marshal(createPaymentRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		RecipientID: recipientID,
+		Reference:   reference,
+		Amount:      amount,
+	})
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/payment_initiation/payment/create", jsonBody, &resp)
+	return resp, err
+}
+
+type createPaymentTokenRequest struct {
+	ClientID  string `json:"client_id"`
+	Secret    string `json:"secret"`
+	PaymentID string `json:"payment_id"`
+}
+
+type CreatePaymentTokenResponse struct {
+	APIResponse
+	PaymentToken               string    `json:"payment_token"`
+	PaymentTokenExpirationTime time.Time `json:"payment_token_expiration_time"`
+}
+
+func (c *Client) CreatePaymentToken(
+	paymentID string,
+) (resp CreatePaymentTokenResponse, err error) {
+	jsonBody, err := json.Marshal(createPaymentTokenRequest{
+		ClientID:  c.clientID,
+		Secret:    c.secret,
+		PaymentID: paymentID,
+	})
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/payment_initiation/payment/token/create", jsonBody, &resp)
+	return resp, err
+}
+
+type getPaymentRequest struct {
+	ClientID  string `json:"client_id"`
+	Secret    string `json:"secret"`
+	PaymentID string `json:"payment_id"`
+}
+
+type Payment struct {
+	PaymentID                  string        `json:"payment_id"`
+	PaymentToken               *string       `json:"payment_token"`
+	Reference                  string        `json:"reference"`
+	Amount                     PaymentAmount `json:"amount"`
+	Status                     string        `json:"status"`
+	LastStatusUpdate           time.Time     `json:"last_status_update"`
+	PaymentTokenExpirationTime *time.Time    `json:"payment_token_expiration_time"`
+	RecipientID                string        `json:"recipient_id"`
+}
+
+type GetPaymentResponse struct {
+	APIResponse
+	Payment
+}
+
+func (c *Client) GetPayment(paymentID string) (resp GetPaymentResponse, err error) {
+	jsonBody, err := json.Marshal(getPaymentRequest{
+		ClientID:  c.clientID,
+		Secret:    c.secret,
+		PaymentID: paymentID,
+	})
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/payment_initiation/payment/get", jsonBody, &resp)
+	return resp, err
+}
+
+type listPaymentsRequest struct {
+	ClientID string  `json:"client_id"`
+	Secret   string  `json:"secret"`
+	Count    *int    `json:"count"`
+	Cursor   *string `json:"cursor"`
+}
+
+type ListPaymentsResponse struct {
+	APIResponse
+	Payments   []Payment `json:"payments"`
+	NextCursor string    `json:"next_cursor"`
+}
+
+type ListPaymentsOptions struct {
+	Count  *int
+	Cursor *string
+}
+
+func (c *Client) ListPayments(options ListPaymentsOptions) (resp ListPaymentsResponse, err error) {
+	jsonBody, err := json.Marshal(listPaymentsRequest{
+		ClientID: c.clientID,
+		Secret:   c.secret,
+		Count:    options.Count,
+		Cursor:   options.Cursor,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/payment_initiation/payment/list", jsonBody, &resp)
+	return resp, err
+}

--- a/plaid/payment_test.go
+++ b/plaid/payment_test.go
@@ -1,0 +1,66 @@
+package plaid
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestPayment(t *testing.T) {
+	paymentRecipientCreateResp, err := testClient.CreatePaymentRecipient("John Doe", "GB33BUKB20201555555555", PaymentRecipientAddress{
+		Street:     []string{"Street Name 999"},
+		City:       "City",
+		PostalCode: "99999",
+		Country:    "GB",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, paymentRecipientCreateResp.RecipientID)
+	recipientID := paymentRecipientCreateResp.RecipientID
+
+	paymentRecipientGetResp, err := testClient.GetPaymentRecipient(paymentRecipientCreateResp.RecipientID)
+	assert.Nil(t, err)
+	assert.NotNil(t, paymentRecipientGetResp.RecipientID)
+	assert.NotNil(t, paymentRecipientGetResp.Name)
+	assert.NotNil(t, paymentRecipientGetResp.IBAN)
+	assert.NotNil(t, paymentRecipientGetResp.Address)
+
+	paymentRecipientListResp, err := testClient.ListPaymentRecipients()
+	assert.Nil(t, err)
+	assert.True(t, len(paymentRecipientListResp.Recipients) > 0)
+
+	paymentCreateResp, err := testClient.CreatePayment(recipientID, "TestPayment", PaymentAmount{
+		Currency: "GBP",
+		Value:    100.0,
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, paymentCreateResp.PaymentID)
+	assert.NotNil(t, paymentCreateResp.Status)
+	paymentID := paymentCreateResp.PaymentID
+
+	paymentTokenCreateResp, err := testClient.CreatePaymentToken(paymentID)
+	assert.Nil(t, err)
+	assert.NotNil(t, paymentTokenCreateResp.PaymentToken)
+	assert.NotNil(t, paymentTokenCreateResp.PaymentTokenExpirationTime)
+
+	paymentGetResp, err := testClient.GetPayment(paymentCreateResp.PaymentID)
+	assert.Nil(t, err)
+	assert.NotNil(t, paymentGetResp.PaymentID)
+	assert.NotNil(t, paymentGetResp.PaymentToken)
+	assert.NotNil(t, paymentGetResp.Reference)
+	assert.NotNil(t, paymentGetResp.Amount)
+	assert.NotNil(t, paymentGetResp.Status)
+	assert.NotNil(t, paymentGetResp.LastStatusUpdate)
+	assert.NotNil(t, paymentGetResp.PaymentTokenExpirationTime)
+	assert.NotNil(t, paymentGetResp.RecipientID)
+
+	count := 10
+	paymentListResp, err := testClient.ListPayments(ListPaymentsOptions{Count: &count})
+	assert.Nil(t, err)
+	assert.True(t, len(paymentListResp.Payments) > 0)
+
+	cursor := paymentListResp.NextCursor
+	if cursor != "" {
+		_, err = testClient.ListPayments(ListPaymentsOptions{Cursor: &cursor})
+		assert.Nil(t, err)
+	}
+}

--- a/plaid/processor.go
+++ b/plaid/processor.go
@@ -10,13 +10,20 @@ type processorTokenRequest struct {
 	Secret      string `json:"secret"`
 	AccessToken string `json:"access_token"`
 	AccountID   string `json:"account_id"`
-	Processor   string `json:"processor"`
+	Processor   string `json:"processor,omitempty"`
 }
 
+// ProcessorTokenResponse defines the generic return format for most processor token requests 
 type ProcessorTokenResponse struct {
 	APIResponse
 	ProcessorToken string `json:"processor_token"`
 }
+// CreateApexTokenResponse defines the return format for Apex processor token requests
+type CreateApexTokenResponse ProcessorTokenResponse
+// CreateDwollaTokenResponse defines the return format for Dwolla processor token requests
+type CreateDwollaTokenResponse ProcessorTokenResponse
+// CreateOcrolusTokenResponse defines the return format for Ocrolus processor token requests 
+type CreateOcrolusTokenResponse ProcessorTokenResponse
 
 type createStripeTokenRequest struct {
 	ClientID    string `json:"client_id"`
@@ -25,6 +32,7 @@ type createStripeTokenRequest struct {
 	AccountID   string `json:"account_id"`
 }
 
+// CreateStripeTokenResponse defines the unique return format for stripe processor token requests 
 type CreateStripeTokenResponse struct {
 	APIResponse
 	StripeBankAccountToken string `json:"stripe_bank_account_token"`
@@ -35,13 +43,18 @@ func (c *Client) requestProcessorToken(apiEndpoint, accessToken, accountID strin
 		return resp, errors.New(apiEndpoint + " - access token and account ID must be specified")
 	}
 
-	jsonBody, err := json.Marshal(processorTokenRequest{
+	requestBody := processorTokenRequest{
 		ClientID:    c.clientID,
 		Secret:      c.secret,
 		AccessToken: accessToken,
 		AccountID:   accountID,
-		Processor:   processor,
-	})
+	}
+
+	if processor != "" {
+		requestBody.Processor = processor
+	}
+
+	jsonBody, err := json.Marshal(requestBody)
 	if err != nil {
 		return resp, err
 	}
@@ -67,21 +80,21 @@ func (c *Client) CreateProcessorToken(accessToken, accountID string, processor s
 }
 
 // CreateApexToken is used to create a new Apex processor token.
-func (c *Client) CreateApexToken(accessToken, accountID string) (resp ProcessorTokenResponse, err error) {
-	response, err := c.requestProcessorToken("/processor/apex/processor_token/create", accessToken, accountID)
-	return ProcessorTokenResponse(response), err
+func (c *Client) CreateApexToken(accessToken, accountID string) (resp CreateApexTokenResponse, err error) {
+	response, err := c.requestProcessorToken("/processor/apex/processor_token/create", accessToken, accountID, "")
+	return CreateApexTokenResponse(response), err
 }
 
 // CreateDwollaToken is used to create a new Dwolla processor token.
-func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp ProcessorTokenResponse, err error) {
-	response, err := c.requestProcessorToken("/processor/dwolla/processor_token/create", accessToken, accountID)
-	return ProcessorTokenResponse(response), err
+func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp CreateDwollaTokenResponse, err error) {
+	response, err := c.requestProcessorToken("/processor/dwolla/processor_token/create", accessToken, accountID, "")
+	return CreateDwollaTokenResponse(response), err
 }
 
 // CreateOcrolusToken is used to create a new Ocrolus processor token.
-func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp ProcessorTokenResponse, err error) {
-	response, err := c.requestProcessorToken("/processor/ocrolus/processor_token/create", accessToken, accountID)
-	return ProcessorTokenResponse(response), err
+func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp CreateOcrolusTokenResponse, err error) {
+	response, err := c.requestProcessorToken("/processor/ocrolus/processor_token/create", accessToken, accountID, "")
+	return CreateOcrolusTokenResponse(response), err
 }
 
 // CreateStripeToken is used to create a new Stripe bank account token.

--- a/plaid/processor.go
+++ b/plaid/processor.go
@@ -5,21 +5,18 @@ import (
 	"errors"
 )
 
-type createProcessorTokenRequest struct {
+type processorTokenRequest struct {
 	ClientID    string `json:"client_id"`
 	Secret      string `json:"secret"`
 	AccessToken string `json:"access_token"`
 	AccountID   string `json:"account_id"`
+	Processor   string `json:"processor"`
 }
 
-type createProcessorTokenResponse struct {
+type ProcessorTokenResponse struct {
 	APIResponse
 	ProcessorToken string `json:"processor_token"`
 }
-
-type CreateApexTokenResponse createProcessorTokenResponse
-type CreateDwollaTokenResponse createProcessorTokenResponse
-type CreateOcrolusTokenResponse createProcessorTokenResponse
 
 type createStripeTokenRequest struct {
 	ClientID    string `json:"client_id"`
@@ -33,16 +30,17 @@ type CreateStripeTokenResponse struct {
 	StripeBankAccountToken string `json:"stripe_bank_account_token"`
 }
 
-func (c *Client) createProcessorToken(apiEndpoint, accessToken, accountID string) (resp createProcessorTokenResponse, err error) {
+func (c *Client) requestProcessorToken(apiEndpoint, accessToken, accountID string, processor string) (resp ProcessorTokenResponse, err error) {
 	if accessToken == "" || accountID == "" {
 		return resp, errors.New(apiEndpoint + " - access token and account ID must be specified")
 	}
 
-	jsonBody, err := json.Marshal(createProcessorTokenRequest{
+	jsonBody, err := json.Marshal(processorTokenRequest{
 		ClientID:    c.clientID,
 		Secret:      c.secret,
 		AccessToken: accessToken,
 		AccountID:   accountID,
+		Processor:   processor,
 	})
 	if err != nil {
 		return resp, err
@@ -52,22 +50,38 @@ func (c *Client) createProcessorToken(apiEndpoint, accessToken, accountID string
 	return resp, err
 }
 
+// CreateProcessorToken is used to create a new generic processor token.
+func (c *Client) CreateProcessorToken(accessToken, accountID string, processor string) (resp ProcessorTokenResponse, err error) {
+	if processor == "" {
+		return resp, errors.New("you must specify a processor")
+	}
+
+	if processor == "stripe" {
+		return resp, errors.New("stripe processor tokens are not compatible with this function, use CreateStripeToken instead")
+	} else if processor == "apex" {
+		return resp, errors.New("apex processor tokens are not compatible with this function, use CreateStripeToken instead")
+	}
+
+	response, err := c.requestProcessorToken("processor/token/create", accessToken, accountID, processor)
+	return ProcessorTokenResponse(response), err
+}
+
 // CreateApexToken is used to create a new Apex processor token.
-func (c *Client) CreateApexToken(accessToken, accountID string) (resp CreateApexTokenResponse, err error) {
-	response, err := c.createProcessorToken("/processor/apex/processor_token/create", accessToken, accountID)
-	return CreateApexTokenResponse(response), err
+func (c *Client) CreateApexToken(accessToken, accountID string) (resp ProcessorTokenResponse, err error) {
+	response, err := c.requestProcessorToken("/processor/apex/processor_token/create", accessToken, accountID)
+	return ProcessorTokenResponse(response), err
 }
 
 // CreateDwollaToken is used to create a new Dwolla processor token.
-func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp CreateDwollaTokenResponse, err error) {
-	response, err := c.createProcessorToken("/processor/dwolla/processor_token/create", accessToken, accountID)
-	return CreateDwollaTokenResponse(response), err
+func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp ProcessorTokenResponse, err error) {
+	response, err := c.requestProcessorToken("/processor/dwolla/processor_token/create", accessToken, accountID)
+	return ProcessorTokenResponse(response), err
 }
 
 // CreateOcrolusToken is used to create a new Ocrolus processor token.
-func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp CreateOcrolusTokenResponse, err error) {
-	response, err := c.createProcessorToken("/processor/ocrolus/processor_token/create", accessToken, accountID)
-	return CreateOcrolusTokenResponse(response), err
+func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp ProcessorTokenResponse, err error) {
+	response, err := c.requestProcessorToken("/processor/ocrolus/processor_token/create", accessToken, accountID)
+	return ProcessorTokenResponse(response), err
 }
 
 // CreateStripeToken is used to create a new Stripe bank account token.

--- a/plaid/processor.go
+++ b/plaid/processor.go
@@ -13,24 +13,31 @@ type processorTokenRequest struct {
 	Processor   string `json:"processor"`
 }
 
-type ProcessorTokenResponse struct {
+// CreateProcessorTokenResponse is the response interface for all token requests
+type CreateProcessorTokenResponse interface {
+	APIResponse
+	GetToken() string
+}
+
+type createGenericProcessorTokenResponse struct {
 	APIResponse
 	ProcessorToken string `json:"processor_token"`
 }
 
-type createStripeTokenRequest struct {
-	ClientID    string `json:"client_id"`
-	Secret      string `json:"secret"`
-	AccessToken string `json:"access_token"`
-	AccountID   string `json:"account_id"`
+func (r *createGenericProcessorTokenResponse) GetToken() string {
+	return r.ProcessorToken
 }
 
-type CreateStripeTokenResponse struct {
+type createStripeTokenResponse struct {
 	APIResponse
 	StripeBankAccountToken string `json:"stripe_bank_account_token"`
 }
 
-func (c *Client) requestProcessorToken(apiEndpoint, accessToken, accountID string, processor string) (resp ProcessorTokenResponse, err error) {
+func (r *createStripeTokenResponse) GetToken() string {
+	return r.StripeBankAccountToken
+}
+
+func (c *Client) requestProcessorToken(apiEndpoint, accessToken, accountID string, processor string) (resp CreateProcessorTokenResponse, err error) {
 	if accessToken == "" || accountID == "" {
 		return resp, errors.New(apiEndpoint + " - access token and account ID must be specified")
 	}
@@ -51,55 +58,43 @@ func (c *Client) requestProcessorToken(apiEndpoint, accessToken, accountID strin
 }
 
 // CreateProcessorToken is used to create a new generic processor token.
-func (c *Client) CreateProcessorToken(accessToken, accountID string, processor string) (resp ProcessorTokenResponse, err error) {
+func (c *Client) CreateProcessorToken(accessToken, accountID string, processor string) (resp CreateProcessorTokenResponse, err error) {
 	if processor == "" {
 		return resp, errors.New("you must specify a processor")
 	}
 
+	endpoint := "processor/token/create"
+
 	if processor == "stripe" {
-		return resp, errors.New("stripe processor tokens are not compatible with this function, use CreateStripeToken instead")
+		endpoint = "/processor/stripe/bank_account_token/create"
 	} else if processor == "apex" {
-		return resp, errors.New("apex processor tokens are not compatible with this function, use CreateStripeToken instead")
+		endpoint = "/processor/apex/processor_token/create"
 	}
 
-	response, err := c.requestProcessorToken("processor/token/create", accessToken, accountID, processor)
-	return ProcessorTokenResponse(response), err
+	response, err := c.requestProcessorToken(endpoint, accessToken, accountID, processor)
+	return CreateProcessorTokenResponse(response), err
 }
 
 // CreateApexToken is used to create a new Apex processor token.
-func (c *Client) CreateApexToken(accessToken, accountID string) (resp ProcessorTokenResponse, err error) {
+func (c *Client) CreateApexToken(accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
 	response, err := c.requestProcessorToken("/processor/apex/processor_token/create", accessToken, accountID)
-	return ProcessorTokenResponse(response), err
+	return CreateProcessorTokenResponse(response), err
 }
 
 // CreateDwollaToken is used to create a new Dwolla processor token.
-func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp ProcessorTokenResponse, err error) {
+func (c *Client) CreateDwollaToken(accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
 	response, err := c.requestProcessorToken("/processor/dwolla/processor_token/create", accessToken, accountID)
-	return ProcessorTokenResponse(response), err
+	return CreateProcessorTokenResponse(response), err
 }
 
 // CreateOcrolusToken is used to create a new Ocrolus processor token.
-func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp ProcessorTokenResponse, err error) {
+func (c *Client) CreateOcrolusToken(accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
 	response, err := c.requestProcessorToken("/processor/ocrolus/processor_token/create", accessToken, accountID)
-	return ProcessorTokenResponse(response), err
+	return CreateProcessorTokenResponse(response), err
 }
 
 // CreateStripeToken is used to create a new Stripe bank account token.
-func (c *Client) CreateStripeToken(accessToken, accountID string) (resp CreateStripeTokenResponse, err error) {
-	if accessToken == "" || accountID == "" {
-		return resp, errors.New("/processor/stripe/bank_account_token/create - access token and account ID must be specified")
-	}
-
-	jsonBody, err := json.Marshal(createStripeTokenRequest{
-		ClientID:    c.clientID,
-		Secret:      c.secret,
-		AccessToken: accessToken,
-		AccountID:   accountID,
-	})
-	if err != nil {
-		return resp, err
-	}
-
-	err = c.Call("/processor/stripe/bank_account_token/create", jsonBody, &resp)
-	return resp, err
+func (c *Client) CreateStripeToken(accessToken, accountID string) (resp CreateProcessorTokenResponse, err error) {
+	response, err := c.requestProcessorToken("/processor/stripe/bank_account_token/create", accessToken, accountID)
+	return CreateProcessorTokenResponse(response), err
 }


### PR DESCRIPTION
Add a new method to generate processor tokens through the generic token create route.
Does not alter or affect any existing exported functions or types.