### PR TITLE
Fix TestGetInstitutions and TestGetInstitutionsByID

### DIFF
--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -54,7 +54,6 @@ func TestGetInstitutionsByID(t *testing.T) {
 	for _, options := range []GetInstitutionByIDOptions{
 		GetInstitutionByIDOptions{},
 		GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
-		GetInstitutionByIDOptions{IncludeOptionalMetadata: true, IncludeStatus: true},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			instResp, err := testClient.GetInstitutionByIDWithOptions(sandboxInstitution, options)
@@ -63,11 +62,6 @@ func TestGetInstitutionsByID(t *testing.T) {
 
 			if options.IncludeOptionalMetadata {
 				assert.NotEmpty(t, instResp.Institution.URL)
-			}
-
-			if options.IncludeStatus {
-				assert.NotEmpty(t, instResp.Institution.InstitutionStatus)
-				assert.True(t, instResp.Institution.InstitutionStatus.ItemLogins.LastStatusChange.Unix() > 0)
 			}
 		})
 	}

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -2,7 +2,6 @@ package plaid
 
 import (
 	"fmt"
-	"sort"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -17,17 +16,10 @@ func TestGetInstitutions(t *testing.T) {
 			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, options)
 			assert.Nil(t, err)
 
-			expectedNames := []string{
-				"Amegy Bank of Texas - Personal Banking",
-				"American Express",
-			}
-			outputNames := []string{}
+			assert.Len(t, instsResp.Institutions, 2)
 			for _, inst := range instsResp.Institutions {
-				outputNames = append(outputNames, inst.Name)
+				assert.NotEmpty(t, inst.Name)
 			}
-			sort.Slice(expectedNames, func(i, j int) bool { return expectedNames[i] < expectedNames[j] })
-			sort.Slice(outputNames, func(i, j int) bool { return outputNames[i] < outputNames[j] })
-			assert.Equal(t, expectedNames, outputNames)
 
 			if options.IncludeOptionalMetadata {
 				for _, inst := range instsResp.Institutions {


### PR DESCRIPTION
The institutions data changes frequently, so any tests that are written directly against institution names are liable to break. If there is not enough traffic to accurately calculate institution status, as is the case in the sandbox environment, the API returns null rather than potentially inaccurate data.