### PR TITLE
Fix status object in /item/get response

### DIFF
--- a/plaid/item.go
+++ b/plaid/item.go
@@ -7,14 +7,13 @@ import (
 )
 
 type Item struct {
-	AvailableProducts     []string   `json:"available_products"`
-	BilledProducts        []string   `json:"billed_products"`
-	Error                 Error      `json:"error"`
-	InstitutionID         string     `json:"institution_id"`
-	ItemID                string     `json:"item_id"`
-	Webhook               string     `json:"webhook"`
-	Status                ItemStatus `json:"status"`
-	ConsentExpirationTime time.Time  `json:"consent_expiration_time"`
+	AvailableProducts     []string  `json:"available_products"`
+	BilledProducts        []string  `json:"billed_products"`
+	Error                 Error     `json:"error"`
+	InstitutionID         string    `json:"institution_id"`
+	ItemID                string    `json:"item_id"`
+	Webhook               string    `json:"webhook"`
+	ConsentExpirationTime time.Time `json:"consent_expiration_time"`
 }
 
 type ItemStatus struct {
@@ -41,7 +40,8 @@ type getItemRequest struct {
 
 type GetItemResponse struct {
 	APIResponse
-	Item Item `json:"item"`
+	Item   Item       `json:"item"`
+	Status ItemStatus `json:"status"`
 }
 
 type removeItemRequest struct {

--- a/plaid/item_test.go
+++ b/plaid/item_test.go
@@ -24,6 +24,7 @@ func TestGetItem(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, itemResp.Item)
+	assert.NotEmpty(t, itemResp.Status)
 }
 
 func TestRemoveItem(t *testing.T) {


### PR DESCRIPTION
Follow-up to https://github.com/plaid/plaid-go/pull/92#issuecomment-576671534. The `ItemStatus` field should be scoped to `GetItemResponse.Status`, not `GetItemResponse.Item.Status`. The diff is easier to follow if you [ignore whitespace](https://github.com/plaid/plaid-go/pull/93/files?w=1).