### PR TITLE
Add /webhook_verification_key/get endpoint to plaid-go

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,4 +117,9 @@ func main() {
 	paymentGetResp, err := client.GetPayment(paymentCreateResp.PaymentID)
 	handleError(err)
 	fmt.Println("Payment get response:", paymentGetResp)
+
+	// POST /webhook_verification_key/get
+	webhookVerificationKeyGetResp, err := client.GetWebhookVerificationKey("6c5516e1-92dc-479e-a8ff-5a51992e0001")
+	handleError(err)
+	fmt.Println("Webhook verification key response:", webhookVerificationKeyGetResp)
 }

--- a/plaid/webhooks.go
+++ b/plaid/webhooks.go
@@ -32,7 +32,7 @@ type getWebhookVerificationKeyRequest struct {
 // See https://plaid.com/docs/#webhook-verification.
 func (c *Client) GetWebhookVerificationKey(
 	keyID string,
-) (resp GetLiabilitiesResponse, err error) {
+) (resp GetWebhookVerificationKeyResponse, err error) {
 	if keyID == "" {
 		return resp, errors.New("/webhook_verification_key/get - key ID must be specified")
 	}

--- a/plaid/webhooks.go
+++ b/plaid/webhooks.go
@@ -1,0 +1,53 @@
+package plaid
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type WebhookVerificationKey struct {
+	Alg       string `json:"alg"`
+	CreatedAt int64  `json:"created_at"`
+	Crv       string `json:"crv"`
+	ExpiredAt int64  `json:"expired_at"`
+	Kid       string `json:"kid"`
+	Kty       string `json:"kty"`
+	Use       string `json:"use"`
+	X         string `json:"x"`
+	Y         string `json:"y"`
+}
+
+type GetWebhookVerificationKeyResponse struct {
+	APIResponse
+	Key WebhookVerificationKey `json:"key"`
+}
+
+type getWebhookVerificationKeyRequest struct {
+	ClientID string `json:"client_id"`
+	Secret   string `json:"secret"`
+	KeyID    string `json:"key_id"`
+}
+
+// GetWebhookVerificationKey retrieves the verification key for a given webhook verification key ID
+// See https://plaid.com/docs/#webhook-verification.
+func (c *Client) GetWebhookVerificationKey(
+	keyID string,
+) (resp GetLiabilitiesResponse, err error) {
+	if keyID == "" {
+		return resp, errors.New("/webhook_verification_key/get - key ID must be specified")
+	}
+
+	req := getWebhookVerificationKeyRequest{
+		ClientID: c.clientID,
+		Secret:   c.secret,
+		KeyID:    keyID,
+	}
+
+	jsonBody, err := json.Marshal(req)
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/webhook_verification_key/get", jsonBody, &resp)
+	return resp, err
+}

--- a/plaid/webhooks_test.go
+++ b/plaid/webhooks_test.go
@@ -11,5 +11,12 @@ func TestGetWebhookVerificationKey(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, webhookResp.Key)
+	assert.NotNil(t, webhookResp.Key.Alg)
+	assert.NotNil(t, webhookResp.Key.CreatedAt)
+	assert.NotNil(t, webhookResp.Key.Crv)
 	assert.NotNil(t, webhookResp.Key.Kid)
+	assert.NotNil(t, webhookResp.Key.Kty)
+	assert.NotNil(t, webhookResp.Key.Use)
+	assert.NotNil(t, webhookResp.Key.X)
+	assert.NotNil(t, webhookResp.Key.Y)
 }

--- a/plaid/webhooks_test.go
+++ b/plaid/webhooks_test.go
@@ -1,0 +1,15 @@
+package plaid
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetWebhookVerificationKey(t *testing.T) {
+	webhookResp, err := testClient.GetWebhookVerificationKey("6c5516e1-92dc-479e-a8ff-5a51992e0001")
+
+	assert.Nil(t, err)
+	assert.NotNil(t, webhookResp.Key)
+	assert.NotNil(t, webhookResp.Key.Kid)
+}


### PR DESCRIPTION
Add support for the `/webhook_verification_key/get` endpoint in `plaid-go