### PR TITLE
Add OAuth support to /institutions endpoints

### DIFF
--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -14,6 +14,7 @@ type Institution struct {
 	Name         string       `json:"name"`
 	Products     []string     `json:"products"`
 	CountryCodes []string     `json:"country_codes"`
+	OAuth        bool         `json:"oauth"`
 
 	// Included when `options.include_status` is true.
 	InstitutionStatus *InstitutionStatus `json:"status,omitempty"`
@@ -71,6 +72,7 @@ type GetInstitutionsOptions struct {
 	Products                []string `json:"products"`
 	IncludeOptionalMetadata bool     `json:"include_optional_metadata"`
 	CountryCodes            []string `json:"country_codes"`
+	OAuth                   bool     `json:"oauth"`
 }
 
 type GetInstitutionsResponse struct {
@@ -106,6 +108,7 @@ type SearchInstitutionsOptions struct {
 	IncludeOptionalMetadata bool                   `json:"include_optional_metadata"`
 	CountryCodes            []string               `json:"country_codes"`
 	AccountFilter           map[string]interface{} `json:"account_filter"`
+	OAuth                   bool                   `json:"oauth"`
 }
 
 type SearchInstitutionsResponse struct {

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -11,6 +11,10 @@ func TestGetInstitutions(t *testing.T) {
 	for _, options := range []GetInstitutionsOptions{
 		GetInstitutionsOptions{},
 		GetInstitutionsOptions{IncludeOptionalMetadata: true},
+		GetInstitutionsOptions{
+			CountryCodes: []string{"GB"},
+			OAuth:        true,
+		},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, options)
@@ -26,6 +30,12 @@ func TestGetInstitutions(t *testing.T) {
 					assert.NotEmpty(t, inst.URL)
 				}
 			}
+
+			if options.OAuth {
+				for _, inst := range instsResp.Institutions {
+					assert.True(t, inst.OAuth)
+				}
+			}
 		})
 	}
 }
@@ -34,6 +44,10 @@ func TestSearchInstitutions(t *testing.T) {
 	for _, options := range []SearchInstitutionsOptions{
 		SearchInstitutionsOptions{},
 		SearchInstitutionsOptions{IncludeOptionalMetadata: true},
+		SearchInstitutionsOptions{
+			CountryCodes: []string{"GB"},
+			OAuth:        true,
+		},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			p := []string{"transactions"}
@@ -44,6 +58,12 @@ func TestSearchInstitutions(t *testing.T) {
 			if options.IncludeOptionalMetadata {
 				for _, inst := range instsResp.Institutions {
 					assert.NotEmpty(t, inst.URL)
+				}
+			}
+
+			if options.OAuth {
+				for _, inst := range instsResp.Institutions {
+					assert.True(t, inst.OAuth)
 				}
 			}
 		})


### PR DESCRIPTION
Adds support for a new `oauth` request option for `/institutions/get` and `/institutions/search`, and adds a new `oauth` field to the institution schema returned by `/institutions/get`, `/institutions/get_by_id`, and `/institutions/search`.