### PR TITLE
Add OAuth support to /institutions endpoints

### DIFF
--- a/plaid/api_test.go
+++ b/plaid/api_test.go
@@ -12,9 +12,9 @@ var (
 	testPublicKey = os.Getenv("PLAID_PUBLIC_KEY")
 	testEnv       = Sandbox
 
-	sandboxInstitution     = "ins_109508"
-	sandboxInstitutionName = "First Platypus Bank"
-	testProducts           = []string{"auth", "identity", "income", "transactions"}
+	sandboxInstitution      = "ins_109508"
+	sandboxInstitutionQuery = "Platypus"
+	testProducts            = []string{"auth", "identity", "income", "transactions"}
 )
 
 var testOptions = ClientOptions{

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -14,6 +14,7 @@ type Institution struct {
 	Name         string       `json:"name"`
 	Products     []string     `json:"products"`
 	CountryCodes []string     `json:"country_codes"`
+	OAuth        bool         `json:"oauth"`
 
 	// Included when `options.include_status` is true.
 	InstitutionStatus *InstitutionStatus `json:"status,omitempty"`
@@ -71,6 +72,7 @@ type GetInstitutionsOptions struct {
 	Products                []string `json:"products"`
 	IncludeOptionalMetadata bool     `json:"include_optional_metadata"`
 	CountryCodes            []string `json:"country_codes"`
+	OAuth                   bool     `json:"oauth"`
 }
 
 type GetInstitutionsResponse struct {
@@ -106,6 +108,7 @@ type SearchInstitutionsOptions struct {
 	IncludeOptionalMetadata bool                   `json:"include_optional_metadata"`
 	CountryCodes            []string               `json:"country_codes"`
 	AccountFilter           map[string]interface{} `json:"account_filter"`
+	OAuth                   bool                   `json:"oauth"`
 }
 
 type SearchInstitutionsResponse struct {

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -72,7 +72,7 @@ type GetInstitutionsOptions struct {
 	Products                []string `json:"products"`
 	IncludeOptionalMetadata bool     `json:"include_optional_metadata"`
 	CountryCodes            []string `json:"country_codes"`
-	OAuth                   bool     `json:"oauth"`
+	OAuth                   *bool    `json:"oauth"`
 }
 
 type GetInstitutionsResponse struct {
@@ -108,7 +108,7 @@ type SearchInstitutionsOptions struct {
 	IncludeOptionalMetadata bool                   `json:"include_optional_metadata"`
 	CountryCodes            []string               `json:"country_codes"`
 	AccountFilter           map[string]interface{} `json:"account_filter"`
-	OAuth                   bool                   `json:"oauth"`
+	OAuth                   *bool                  `json:"oauth"`
 }
 
 type SearchInstitutionsResponse struct {

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -11,6 +11,10 @@ func TestGetInstitutions(t *testing.T) {
 	for _, options := range []GetInstitutionsOptions{
 		GetInstitutionsOptions{},
 		GetInstitutionsOptions{IncludeOptionalMetadata: true},
+		GetInstitutionsOptions{
+			CountryCodes: []string{"GB"},
+			OAuth:        true,
+		},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, options)
@@ -26,6 +30,11 @@ func TestGetInstitutions(t *testing.T) {
 					assert.NotEmpty(t, inst.URL)
 				}
 			}
+			if options.OAuth {
+				for _, inst := range instsResp.Institutions {
+					assert.True(t, inst.OAuth)
+				}
+			}
 		})
 	}
 }
@@ -34,16 +43,25 @@ func TestSearchInstitutions(t *testing.T) {
 	for _, options := range []SearchInstitutionsOptions{
 		SearchInstitutionsOptions{},
 		SearchInstitutionsOptions{IncludeOptionalMetadata: true},
+		SearchInstitutionsOptions{
+			CountryCodes: []string{"GB"},
+			OAuth:        true,
+		},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			p := []string{"transactions"}
-			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionName, p, options)
+			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, options)
 			assert.Nil(t, err)
 			assert.True(t, len(instsResp.Institutions) > 0)
 
 			if options.IncludeOptionalMetadata {
 				for _, inst := range instsResp.Institutions {
 					assert.NotEmpty(t, inst.URL)
+				}
+			}
+			if options.OAuth {
+				for _, inst := range instsResp.Institutions {
+					assert.True(t, inst.OAuth)
 				}
 			}
 		})

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -7,13 +7,15 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
+var oauthTrue = true
+
 func TestGetInstitutions(t *testing.T) {
 	for _, options := range []GetInstitutionsOptions{
 		GetInstitutionsOptions{},
 		GetInstitutionsOptions{IncludeOptionalMetadata: true},
 		GetInstitutionsOptions{
 			CountryCodes: []string{"GB"},
-			OAuth:        true,
+			OAuth:        &oauthTrue,
 		},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
@@ -30,9 +32,9 @@ func TestGetInstitutions(t *testing.T) {
 					assert.NotEmpty(t, inst.URL)
 				}
 			}
-			if options.OAuth {
+			if options.OAuth != nil {
 				for _, inst := range instsResp.Institutions {
-					assert.True(t, inst.OAuth)
+					assert.Equal(t, inst.OAuth, *options.OAuth)
 				}
 			}
 		})
@@ -45,7 +47,7 @@ func TestSearchInstitutions(t *testing.T) {
 		SearchInstitutionsOptions{IncludeOptionalMetadata: true},
 		SearchInstitutionsOptions{
 			CountryCodes: []string{"GB"},
-			OAuth:        true,
+			OAuth:        &oauthTrue,
 		},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
@@ -59,9 +61,9 @@ func TestSearchInstitutions(t *testing.T) {
 					assert.NotEmpty(t, inst.URL)
 				}
 			}
-			if options.OAuth {
+			if options.OAuth != nil {
 				for _, inst := range instsResp.Institutions {
-					assert.True(t, inst.OAuth)
+					assert.Equal(t, inst.OAuth, *options.OAuth)
 				}
 			}
 		})


### PR DESCRIPTION
Adds support for a new `oauth` request option for `/institutions/get` and `/institutions/search`, and adds a new `oauth` field to the institution schema returned by `/institutions/get`, `/institutions/get_by_id`, and `/institutions/search`.