### PR TITLE
Set verification status sandbox endpoint

### DIFF
--- a/plaid/sandbox.go
+++ b/plaid/sandbox.go
@@ -86,9 +86,8 @@ func (c *Client) SetSandboxItemVerificationStatus(accessToken string, accountID 
 		return resp, errors.New("/sandbox/item/set_verification_status - accountID must be specified")
 	}
 
-	if !(verificationStatus == "automatically_verified" ||
-		verificationStatus != "manually_verified") {
-		return resp, errors.New("/sandbox/item/set_verification_status - verification status must be 'automatically_verified' or 'manually_verified'")
+	if verificationStatus == "" {
+		return resp, errors.New("/sandbox/item/set_verification_status - verification status must be specified")
 	}
 
 	jsonBody, err := json.Marshal(setSandboxItemVerificationStatusRequest{

--- a/plaid/sandbox.go
+++ b/plaid/sandbox.go
@@ -32,7 +32,7 @@ type setSandboxItemVerificationStatusRequest struct {
 	Secret             string `json:"secret"`
 	AccessToken        string `json:"access_token"`
 	AccountID          string `json:"account_id"`
-	VerificationStatus string `json:"access_token"`
+	VerificationStatus string `json:"verification_status"`
 }
 
 type SetSandboxItemVerificationStatusResponse struct {
@@ -77,7 +77,6 @@ func (c *Client) ResetSandboxItem(accessToken string) (resp ResetSandboxItemResp
 	return resp, err
 }
 
-
 func (c *Client) SetSandboxItemVerificationStatus(accessToken string, accountID string, verificationStatus string) (resp SetSandboxItemVerificationStatusResponse, err error) {
 	if accessToken == "" {
 		return resp, errors.New("/sandbox/item/set_verification_status - access token must be specified")
@@ -88,15 +87,15 @@ func (c *Client) SetSandboxItemVerificationStatus(accessToken string, accountID 
 	}
 
 	if !(verificationStatus == "automatically_verified" ||
-		   verificationStatus != "manually_verified") {
+		verificationStatus != "manually_verified") {
 		return resp, errors.New("/sandbox/item/set_verification_status - verification status must be 'automatically_verified' or 'manually_verified'")
 	}
 
 	jsonBody, err := json.Marshal(setSandboxItemVerificationStatusRequest{
-		ClientID:    c.clientID,
-		Secret:      c.secret,
-		AccessToken: accessToken,
-		AccountID: accountID,
+		ClientID:           c.clientID,
+		Secret:             c.secret,
+		AccessToken:        accessToken,
+		AccountID:          accountID,
 		VerificationStatus: verificationStatus,
 	})
 

--- a/plaid/sandbox.go
+++ b/plaid/sandbox.go
@@ -27,6 +27,18 @@ type ResetSandboxItemResponse struct {
 	ResetLogin bool `json:"reset_login"`
 }
 
+type setSandboxItemVerificationStatusRequest struct {
+	ClientID           string `json:"client_id"`
+	Secret             string `json:"secret"`
+	AccessToken        string `json:"access_token"`
+	AccountID          string `json:"account_id"`
+	VerificationStatus string `json:"access_token"`
+}
+
+type SetSandboxItemVerificationStatusResponse struct {
+	APIResponse
+}
+
 func (c *Client) CreateSandboxPublicToken(institutionID string, initialProducts []string) (resp CreateSandboxPublicTokenResponse, err error) {
 	if institutionID == "" || len(initialProducts) == 0 {
 		return resp, errors.New("/sandbox/public_token/create - institution id and initial products must be specified")
@@ -62,5 +74,36 @@ func (c *Client) ResetSandboxItem(accessToken string) (resp ResetSandboxItemResp
 	}
 
 	err = c.Call("/sandbox/item/reset_login", jsonBody, &resp)
+	return resp, err
+}
+
+
+func (c *Client) SetSandboxItemVerificationStatus(accessToken string, accountID string, verificationStatus string) (resp SetSandboxItemVerificationStatusResponse, err error) {
+	if accessToken == "" {
+		return resp, errors.New("/sandbox/item/set_verification_status - access token must be specified")
+	}
+
+	if accountID == "" {
+		return resp, errors.New("/sandbox/item/set_verification_status - accountID must be specified")
+	}
+
+	if !(verificationStatus == "automatically_verified" ||
+		   verificationStatus != "manually_verified") {
+		return resp, errors.New("/sandbox/item/set_verification_status - verification status must be 'automatically_verified' or 'manually_verified'")
+	}
+
+	jsonBody, err := json.Marshal(setSandboxItemVerificationStatusRequest{
+		ClientID:    c.clientID,
+		Secret:      c.secret,
+		AccessToken: accessToken,
+		AccountID: accountID,
+		VerificationStatus: verificationStatus,
+	})
+
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/sandbox/item/set_verification_status", jsonBody, &resp)
 	return resp, err
 }


### PR DESCRIPTION
Picking up where https://github.com/plaid/plaid-go/pull/77 left off

## Testing
```
package main

import (
        "fmt"
        "net/http"

        "github.com/plaid/plaid-go/plaid"
)

func handleError(err error) {
        if err != nil {
                panic(err)
        }
}

func main() {
        // Creates a new Plaid Client
        clientOptions := plaid.ClientOptions{
                "...",
                "...",
                "...",
                plaid.Sandbox,
                &http.Client{},
        }
        client, err := plaid.NewClient(clientOptions)
        handleError(err)

        resp, err := client.SetSandboxItemVerificationStatus("...", "qge3n39V4didmAbA6R7JiMXaj4zm5GFdPjgE7", "verification_expired")
        handleError(err)
        fmt.Println(resp)
}
```