### PR TITLE
Add authorized_date and payment_channel to Transaction struct

### DIFF
--- a/plaid/transactions.go
+++ b/plaid/transactions.go
@@ -13,12 +13,14 @@ type Transaction struct {
 	Category               []string `json:"category"`
 	CategoryID             string   `json:"category_id"`
 	Date                   string   `json:"date"`
+	AuthorizedDate         string   `json:"authorized_date"`
 
 	Location Location `json:"location"`
 
 	Name string `json:"name"`
 
-	PaymentMeta PaymentMeta `json:"payment_meta"`
+	PaymentMeta    PaymentMeta `json:"payment_meta"`
+	PaymentChannel string      `json:"payment_channel"`
 
 	Pending              bool   `json:"pending"`
 	PendingTransactionID string `json:"pending_transaction_id"`


### PR DESCRIPTION
Adds the missing `authorized_date` and `payment_channel` fields to the `Transaction` struct.

Related Issue: #102 

References:
- [The **Changelog - January 2020** Blog Post](https://blog.plaid.com/changelog-january-2020/)
- [The **Transaction Schema** Documentation](plaid.com/docs/#transaction-schema)