### PR TITLE
Don't assume a particular number of sandbox accounts

### DIFF
--- a/plaid/accounts_test.go
+++ b/plaid/accounts_test.go
@@ -17,7 +17,7 @@ func TestGetAccounts(t *testing.T) {
 	accountsResp, err := testClient.GetAccountsWithOptions(tokenResp.AccessToken, options)
 	assert.Nil(t, err)
 	assert.NotNil(t, accountsResp.Accounts)
-	assert.Equal(t, len(accountsResp.Accounts), 8)
+	assert.True(t, len(accountsResp.Accounts) > 1)
 	assert.NotNil(t, accountsResp.Item)
 
 	// get selected accounts


### PR DESCRIPTION
Tests appear to be failing because of this assumption.