### PR TITLE
Fix link token unit test

### DIFF
--- a/plaid/link_token_test.go
+++ b/plaid/link_token_test.go
@@ -29,7 +29,7 @@ func TestCreateLinkTokenOptional(t *testing.T) {
 		User: &LinkTokenUser{
 			ClientUserID:             time.Now().String(),
 			LegalName:                "Legal Name",
-			PhoneNumber:              "1234567890",
+			PhoneNumber:              "2025550165",
 			EmailAddress:             "test@email.com",
 			PhoneNumberVerifiedTime:  time.Now(),
 			EmailAddressVerifiedTime: time.Now(),


### PR DESCRIPTION
The phone number we were using "1234567890" is not a valid phone number. This updates the test to use a valid phone number instead.