### PR TITLE
remove legacy token endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 6.0.0
+
+BREAKING CHANGES: 
+
+- The library has been pinned to the '2020-09-14' API release. Visit the [docs](https://plaid.com/docs/api/versioning/) to see what changed.
+- the `/item/public_token/create` endpoint has been disabled in favor of the /link/token/create
+    endpoint
+- The `/item/add_token/create endpoint` has been disabled in favor of the /link/token/create
+- The `/payment_initiation/payment/token/create` endpoint has been disabled in favor of the /link/token/create
+    endpoint
+- The `/item/remove` endpoint will no longer return a `removed` boolean.
+- The `/institutions/get`, `/institutions/get_by_id`, and `/institutions/search` now require
+    `country_codes` to be passed in.
+
 ## 5.1.0
 
 - Add support for Link Token get endpoint ([#142](https://github.com/plaid/plaid-go/pull/142))

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Each major version of `plaid-go` targets a specific version of the Plaid API:
 
 | API version | plaid-go release |
 | ----------- | ------------------ |
+| [`2020-09-14`][api-version-2020-09-14] (**latest**) | `6.x.x` |
 | [`2019-05-29`][api-version-2019-05-29] (**latest**) | `2.x.x` |
 | [`2018-05-22`][api-version-2018-05-22] | `1.x.x` |
 | `2017-03-08` | not supported |
@@ -93,3 +94,4 @@ Open an [issue](https://github.com/plaid/plaid-go/issues/new)!
 [version-changelog]: https://plaid.com/docs/api-upgrades/#version-changelog
 [api-version-2018-05-22]: https://plaid.com/docs/api-upgrades/#2018-05-22
 [api-version-2019-05-29]: https://plaid.com/docs/api-upgrades/#2019-05-29
+[api-version-2020-09-14]: https://plaid.com/docs/api-upgrades/#2020-09-14

--- a/main.go
+++ b/main.go
@@ -115,11 +115,6 @@ func main() {
 	handleError(err)
 	fmt.Println("Payment ID:", paymentCreateResp.PaymentID)
 
-	// POST /payment_initiation/payment/token/create
-	paymentTokenCreateResp, err := client.CreatePaymentToken(paymentCreateResp.PaymentID)
-	handleError(err)
-	fmt.Println("Payment Token:", paymentTokenCreateResp.PaymentToken)
-
 	// POST /payment_initiation/payment/get
 	paymentGetResp, err := client.GetPayment(paymentCreateResp.PaymentID)
 	handleError(err)

--- a/main.go
+++ b/main.go
@@ -27,17 +27,17 @@ func main() {
 	handleError(err)
 
 	// POST /institutions/get
-	instsResp, err := client.GetInstitutions(5, 0)
+	instsResp, err := client.GetInstitutions(5, 0, []string{"US"})
 	handleError(err)
 	fmt.Println(instsResp.Institutions[0].Name, "has products:", instsResp.Institutions[0].Products)
 
 	// POST /institutions/get_by_id
-	instResp, err := client.GetInstitutionByID(instsResp.Institutions[0].ID)
+	instResp, err := client.GetInstitutionByID(instsResp.Institutions[0].ID, []string{"US"})
 	handleError(err)
 	fmt.Println(instResp.Institution.Name, "has MFA:", instResp.Institution.MFA)
 
 	// POST /institutions/search
-	instSearchResp, err := client.SearchInstitutions("Ally", []string{"transactions"})
+	instSearchResp, err := client.SearchInstitutions("Ally", []string{"transactions"}, []string{"US"})
 	handleError(err)
 	fmt.Println(instSearchResp.Institutions[0].Name, "has ID:", instSearchResp.Institutions[0].ID)
 

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -61,17 +61,17 @@ type Credential struct {
 }
 
 type getInstitutionsRequest struct {
-	ClientID string                 `json:"client_id"`
-	Secret   string                 `json:"secret"`
-	Count    int                    `json:"count"`
-	Offset   int                    `json:"offset"`
-	Options  GetInstitutionsOptions `json:"options,omitempty"`
+	ClientID     string                 `json:"client_id"`
+	Secret       string                 `json:"secret"`
+	Count        int                    `json:"count"`
+	Offset       int                    `json:"offset"`
+	CountryCodes []string               `json:"country_codes"`
+	Options      GetInstitutionsOptions `json:"options,omitempty"`
 }
 
 type GetInstitutionsOptions struct {
 	Products                []string `json:"products"`
 	IncludeOptionalMetadata bool     `json:"include_optional_metadata"`
-	CountryCodes            []string `json:"country_codes"`
 	OAuth                   *bool    `json:"oauth"`
 }
 
@@ -82,10 +82,11 @@ type GetInstitutionsResponse struct {
 }
 
 type getInstitutionByIDRequest struct {
-	ID       string                    `json:"institution_id"`
-	ClientID string                    `json:"client_id"`
-	Secret   string                    `json:"secret"`
-	Options  GetInstitutionByIDOptions `json:"options,omitempty"`
+	ID           string                    `json:"institution_id"`
+	CountryCodes []string                  `json:"country_codes"`
+	ClientID     string                    `json:"client_id"`
+	Secret       string                    `json:"secret"`
+	Options      GetInstitutionByIDOptions `json:"options,omitempty"`
 }
 
 type GetInstitutionByIDOptions struct {
@@ -99,16 +100,16 @@ type GetInstitutionByIDResponse struct {
 }
 
 type searchInstitutionsRequest struct {
-	Query    string                    `json:"query"`
-	Products []string                  `json:"products"`
-	ClientID string                    `json:"client_id"`
-	Secret   string                    `json:"secret"`
-	Options  SearchInstitutionsOptions `json:"options,omitempty"`
+	Query        string                    `json:"query"`
+	CountryCodes []string                  `json:"country_codes"`
+	Products     []string                  `json:"products"`
+	ClientID     string                    `json:"client_id"`
+	Secret       string                    `json:"secret"`
+	Options      SearchInstitutionsOptions `json:"options,omitempty"`
 }
 
 type SearchInstitutionsOptions struct {
 	IncludeOptionalMetadata bool                   `json:"include_optional_metadata"`
-	CountryCodes            []string               `json:"country_codes"`
 	AccountFilter           map[string]interface{} `json:"account_filter"`
 	OAuth                   *bool                  `json:"oauth"`
 }
@@ -122,14 +123,16 @@ type SearchInstitutionsResponse struct {
 // See https://plaid.com/docs/api/#institutions-by-id.
 func (c *Client) GetInstitutionByID(
 	id string,
+	countryCodes []string,
 ) (resp GetInstitutionByIDResponse, err error) {
-	return c.GetInstitutionByIDWithOptions(id, GetInstitutionByIDOptions{})
+	return c.GetInstitutionByIDWithOptions(id, countryCodes, GetInstitutionByIDOptions{})
 }
 
 // GetInstitutionByIDWithOptions returns information for a single institution given an ID.
 // See https://plaid.com/docs/api/#institutions-by-id.
 func (c *Client) GetInstitutionByIDWithOptions(
 	id string,
+	countryCodes []string,
 	options GetInstitutionByIDOptions,
 ) (resp GetInstitutionByIDResponse, err error) {
 	if id == "" {
@@ -137,10 +140,11 @@ func (c *Client) GetInstitutionByIDWithOptions(
 	}
 
 	jsonBody, err := json.Marshal(getInstitutionByIDRequest{
-		ID:       id,
-		ClientID: c.clientID,
-		Secret:   c.secret,
-		Options:  options,
+		ID:           id,
+		CountryCodes: countryCodes,
+		ClientID:     c.clientID,
+		Secret:       c.secret,
+		Options:      options,
 	})
 
 	if err != nil {
@@ -153,8 +157,8 @@ func (c *Client) GetInstitutionByIDWithOptions(
 
 // GetInstitutions returns information for all institutions supported by Plaid.
 // See https://plaid.com/docs/api/#all-institutions.
-func (c *Client) GetInstitutions(count, offset int) (resp GetInstitutionsResponse, err error) {
-	return c.GetInstitutionsWithOptions(count, offset, GetInstitutionsOptions{})
+func (c *Client) GetInstitutions(count, offset int, countryCodes []string) (resp GetInstitutionsResponse, err error) {
+	return c.GetInstitutionsWithOptions(count, offset, countryCodes, GetInstitutionsOptions{})
 }
 
 // GetInstitutionsWithOptions returns information for all institutions supported by Plaid.
@@ -162,6 +166,7 @@ func (c *Client) GetInstitutions(count, offset int) (resp GetInstitutionsRespons
 func (c *Client) GetInstitutionsWithOptions(
 	count int,
 	offset int,
+	countryCodes []string,
 	options GetInstitutionsOptions,
 ) (resp GetInstitutionsResponse, err error) {
 	if count == 0 {
@@ -169,11 +174,12 @@ func (c *Client) GetInstitutionsWithOptions(
 	}
 
 	jsonBody, err := json.Marshal(getInstitutionsRequest{
-		ClientID: c.clientID,
-		Secret:   c.secret,
-		Count:    count,
-		Offset:   offset,
-		Options:  options,
+		ClientID:     c.clientID,
+		Secret:       c.secret,
+		Count:        count,
+		Offset:       offset,
+		CountryCodes: countryCodes,
+		Options:      options,
 	})
 
 	if err != nil {
@@ -190,8 +196,9 @@ func (c *Client) GetInstitutionsWithOptions(
 func (c *Client) SearchInstitutions(
 	query string,
 	products []string,
+	countryCodes []string,
 ) (resp SearchInstitutionsResponse, err error) {
-	return c.SearchInstitutionsWithOptions(query, products, SearchInstitutionsOptions{})
+	return c.SearchInstitutionsWithOptions(query, products, countryCodes, SearchInstitutionsOptions{})
 }
 
 // SearchInstitutionsWithOptions returns institutions corresponding to a query string and
@@ -200,6 +207,7 @@ func (c *Client) SearchInstitutions(
 func (c *Client) SearchInstitutionsWithOptions(
 	query string,
 	products []string,
+	countryCodes []string,
 	options SearchInstitutionsOptions,
 ) (resp SearchInstitutionsResponse, err error) {
 	if query == "" {
@@ -207,11 +215,12 @@ func (c *Client) SearchInstitutionsWithOptions(
 	}
 
 	jsonBody, err := json.Marshal(searchInstitutionsRequest{
-		Query:    query,
-		Products: products,
-		ClientID: c.clientID,
-		Secret:   c.secret,
-		Options:  options,
+		Query:        query,
+		Products:     products,
+		CountryCodes: countryCodes,
+		ClientID:     c.clientID,
+		Secret:       c.secret,
+		Options:      options,
 	})
 
 	if err != nil {

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -1,7 +1,6 @@
 package plaid
 
 import (
-	"fmt"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -10,31 +9,54 @@ import (
 var oauthTrue = true
 
 func TestGetInstitutions(t *testing.T) {
-	for _, options := range []GetInstitutionsOptions{
-		GetInstitutionsOptions{},
-		GetInstitutionsOptions{IncludeOptionalMetadata: true},
-		GetInstitutionsOptions{
-			CountryCodes: []string{"GB"},
-			OAuth:        &oauthTrue,
+	testCases := []struct {
+		desc         string
+		countryCodes []string
+		options      GetInstitutionsOptions
+	}{
+		{
+			desc:         "succeeds without options",
+			countryCodes: []string{"US"},
+			options:      GetInstitutionsOptions{},
 		},
-	} {
-		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
-			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, options)
-			assert.Nil(t, err)
+		{
+			desc:         "succeeds with optional metadata",
+			countryCodes: []string{"US"},
+			options:      GetInstitutionsOptions{IncludeOptionalMetadata: true},
+		},
+		{
+			desc:         "succeeds for oauth institutions",
+			countryCodes: []string{"GB"},
+			options:      GetInstitutionsOptions{OAuth: &oauthTrue},
+		},
+		{
+			desc:         "errors without country codes",
+			countryCodes: []string{},
+			options:      GetInstitutionsOptions{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, tc.countryCodes, tc.options)
+			if len(tc.countryCodes) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
 
-			assert.Len(t, instsResp.Institutions, 2)
-			for _, inst := range instsResp.Institutions {
-				assert.NotEmpty(t, inst.Name)
-			}
-
-			if options.IncludeOptionalMetadata {
+				assert.Len(t, instsResp.Institutions, 2)
 				for _, inst := range instsResp.Institutions {
-					assert.NotEmpty(t, inst.URL)
+					assert.NotEmpty(t, inst.Name)
 				}
-			}
-			if options.OAuth != nil {
-				for _, inst := range instsResp.Institutions {
-					assert.Equal(t, inst.OAuth, *options.OAuth)
+
+				if tc.options.IncludeOptionalMetadata {
+					for _, inst := range instsResp.Institutions {
+						assert.NotEmpty(t, inst.URL)
+					}
+				}
+				if tc.options.OAuth != nil {
+					for _, inst := range instsResp.Institutions {
+						assert.Equal(t, inst.OAuth, *tc.options.OAuth)
+					}
 				}
 			}
 		})
@@ -42,28 +64,51 @@ func TestGetInstitutions(t *testing.T) {
 }
 
 func TestSearchInstitutions(t *testing.T) {
-	for _, options := range []SearchInstitutionsOptions{
-		SearchInstitutionsOptions{},
-		SearchInstitutionsOptions{IncludeOptionalMetadata: true},
-		SearchInstitutionsOptions{
-			CountryCodes: []string{"GB"},
-			OAuth:        &oauthTrue,
+	testCases := []struct {
+		desc         string
+		countryCodes []string
+		options      SearchInstitutionsOptions
+	}{
+		{
+			desc:         "succeeds without options",
+			countryCodes: []string{"US"},
+			options:      SearchInstitutionsOptions{},
 		},
-	} {
-		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
+		{
+			desc:         "succeeds with optional metadata",
+			countryCodes: []string{"US"},
+			options:      SearchInstitutionsOptions{IncludeOptionalMetadata: true},
+		},
+		{
+			desc:         "succeeds for oauth institutions",
+			countryCodes: []string{"GB"},
+			options:      SearchInstitutionsOptions{OAuth: &oauthTrue},
+		},
+		{
+			desc:         "errors without country codes",
+			countryCodes: []string{},
+			options:      SearchInstitutionsOptions{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
 			p := []string{"transactions"}
-			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, options)
-			assert.Nil(t, err)
-			assert.True(t, len(instsResp.Institutions) > 0)
+			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, tc.countryCodes, tc.options)
+			if len(tc.countryCodes) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.True(t, len(instsResp.Institutions) > 0)
 
-			if options.IncludeOptionalMetadata {
-				for _, inst := range instsResp.Institutions {
-					assert.NotEmpty(t, inst.URL)
+				if tc.options.IncludeOptionalMetadata {
+					for _, inst := range instsResp.Institutions {
+						assert.NotEmpty(t, inst.URL)
+					}
 				}
-			}
-			if options.OAuth != nil {
-				for _, inst := range instsResp.Institutions {
-					assert.Equal(t, inst.OAuth, *options.OAuth)
+				if tc.options.OAuth != nil {
+					for _, inst := range instsResp.Institutions {
+						assert.Equal(t, inst.OAuth, *tc.options.OAuth)
+					}
 				}
 			}
 		})
@@ -71,20 +116,41 @@ func TestSearchInstitutions(t *testing.T) {
 }
 
 func TestGetInstitutionsByID(t *testing.T) {
-	for _, options := range []GetInstitutionByIDOptions{
-		GetInstitutionByIDOptions{},
-		GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
-	} {
-		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		countryCodes []string
+		options      GetInstitutionByIDOptions
+	}{
+		{
+			desc:         "succeeds without options",
+			countryCodes: []string{"US"},
+			options:      GetInstitutionByIDOptions{},
+		},
+		{
+			desc:         "succeeds with optional metadata",
+			countryCodes: []string{"US"},
+			options:      GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
+		},
+		{
+			desc:         "errors without country codes",
+			countryCodes: []string{},
+			options:      GetInstitutionByIDOptions{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
 			// can't use the normal sandbox institution because it only returns the ItemLogins status.
 			institutionID := "ins_12"
+			instResp, err := testClient.GetInstitutionByIDWithOptions(institutionID, tc.countryCodes, tc.options)
+			if len(tc.countryCodes) == 0 {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.True(t, len(instResp.Institution.Products) > 0)
 
-			instResp, err := testClient.GetInstitutionByIDWithOptions(institutionID, options)
-			assert.Nil(t, err)
-			assert.True(t, len(instResp.Institution.Products) > 0)
-
-			if options.IncludeOptionalMetadata {
-				assert.NotEmpty(t, instResp.Institution.URL)
+				if tc.options.IncludeOptionalMetadata {
+					assert.NotEmpty(t, instResp.Institution.URL)
+				}
 			}
 		})
 	}

--- a/plaid/item.go
+++ b/plaid/item.go
@@ -52,7 +52,6 @@ type removeItemRequest struct {
 
 type RemoveItemResponse struct {
 	APIResponse
-	Removed bool `json:"removed"`
 }
 
 type updateItemWebhookRequest struct {
@@ -82,27 +81,6 @@ type createPublicTokenRequest struct {
 	ClientID    string `json:"client_id"`
 	Secret      string `json:"secret"`
 	AccessToken string `json:"access_token"`
-}
-
-type CreatePublicTokenResponse struct {
-	APIResponse
-	PublicToken string `json:"public_token"`
-}
-
-type createItemAddTokenRequest struct {
-	ClientID   string                 `json:"client_id"`
-	Secret     string                 `json:"secret"`
-	UserFields ItemAddTokenUserFields `json:"user"`
-}
-
-type ItemAddTokenUserFields struct {
-	ClientUserID string `json:"client_user_id"`
-}
-
-type CreateItemAddTokenResponse struct {
-	APIResponse
-	AddToken   string    `json:"add_token"`
-	Expiration time.Time `json:"expiration"`
 }
 
 type exchangePublicTokenRequest struct {
@@ -217,44 +195,6 @@ func (c *Client) InvalidateAccessToken(accessToken string) (resp InvalidateAcces
 	}
 
 	err = c.Call("/item/access_token/invalidate", jsonBody, &resp)
-	return resp, err
-}
-
-// CreatePublicToken generates a one-time use public token which expires in
-// 30 minutes to update an Item.
-// See https://plaid.com/docs/api/#creating-public-tokens.
-func (c *Client) CreatePublicToken(accessToken string) (resp CreatePublicTokenResponse, err error) {
-	if accessToken == "" {
-		return resp, errors.New("/item/public_token/create - access token must be specified")
-	}
-
-	jsonBody, err := json.Marshal(createPublicTokenRequest{
-		ClientID:    c.clientID,
-		Secret:      c.secret,
-		AccessToken: accessToken,
-	})
-
-	if err != nil {
-		return resp, err
-	}
-
-	err = c.Call("/item/public_token/create", jsonBody, &resp)
-	return resp, err
-}
-
-// CreateItemAddToken generates a token which is used to initialize Link.
-func (c *Client) CreateItemAddToken(userFields ItemAddTokenUserFields) (resp CreateItemAddTokenResponse, err error) {
-	jsonBody, err := json.Marshal(createItemAddTokenRequest{
-		ClientID:   c.clientID,
-		Secret:     c.secret,
-		UserFields: userFields,
-	})
-
-	if err != nil {
-		return resp, err
-	}
-
-	err = c.Call("/item/add_token/create", jsonBody, &resp)
 	return resp, err
 }
 

--- a/plaid/item_test.go
+++ b/plaid/item_test.go
@@ -33,7 +33,6 @@ func TestRemoveItem(t *testing.T) {
 	itemResp, err := testClient.RemoveItem(tokenResp.AccessToken)
 
 	assert.Nil(t, err)
-	assert.True(t, itemResp.Removed)
 }
 
 func TestUpdateItemWebhook(t *testing.T) {
@@ -53,26 +52,6 @@ func TestInvalidateAccessToken(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, newTokenResp.NewAccessToken)
-}
-
-func TestCreatePublicToken(t *testing.T) {
-	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
-	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	publicTokenResp, err := testClient.CreatePublicToken(tokenResp.AccessToken)
-
-	assert.Nil(t, err)
-	assert.True(t, strings.HasPrefix(publicTokenResp.PublicToken, "public-sandbox"))
-}
-
-func TestCreateItemAddToken(t *testing.T) {
-	fakeClientUserID, _ := randomHex(12)
-	itemAddTokenResp, err := testClient.CreateItemAddToken(ItemAddTokenUserFields{
-		ClientUserID: fakeClientUserID,
-	})
-
-	assert.Nil(t, err)
-	assert.True(t, strings.HasPrefix(itemAddTokenResp.AddToken, "item-add-sandbox"))
-	assert.NotZero(t, itemAddTokenResp.Expiration)
 }
 
 func TestExchangePublicToken(t *testing.T) {

--- a/plaid/item_test.go
+++ b/plaid/item_test.go
@@ -30,7 +30,7 @@ func TestGetItem(t *testing.T) {
 func TestRemoveItem(t *testing.T) {
 	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
 	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
-	itemResp, err := testClient.RemoveItem(tokenResp.AccessToken)
+	_, err := testClient.RemoveItem(tokenResp.AccessToken)
 
 	assert.Nil(t, err)
 }

--- a/plaid/item_test.go
+++ b/plaid/item_test.go
@@ -24,7 +24,6 @@ func TestGetItem(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotEqual(t, Item{}, itemResp.Item)
-	assert.NotEmpty(t, itemResp.Status)
 }
 
 func TestRemoveItem(t *testing.T) {

--- a/plaid/payment.go
+++ b/plaid/payment.go
@@ -157,34 +157,6 @@ func (c *Client) CreatePayment(
 	return resp, err
 }
 
-type createPaymentTokenRequest struct {
-	ClientID  string `json:"client_id"`
-	Secret    string `json:"secret"`
-	PaymentID string `json:"payment_id"`
-}
-
-type CreatePaymentTokenResponse struct {
-	APIResponse
-	PaymentToken               string    `json:"payment_token"`
-	PaymentTokenExpirationTime time.Time `json:"payment_token_expiration_time"`
-}
-
-func (c *Client) CreatePaymentToken(
-	paymentID string,
-) (resp CreatePaymentTokenResponse, err error) {
-	jsonBody, err := json.Marshal(createPaymentTokenRequest{
-		ClientID:  c.clientID,
-		Secret:    c.secret,
-		PaymentID: paymentID,
-	})
-	if err != nil {
-		return resp, err
-	}
-
-	err = c.Call("/payment_initiation/payment/token/create", jsonBody, &resp)
-	return resp, err
-}
-
 type getPaymentRequest struct {
 	ClientID  string `json:"client_id"`
 	Secret    string `json:"secret"`
@@ -192,14 +164,12 @@ type getPaymentRequest struct {
 }
 
 type Payment struct {
-	PaymentID                  string        `json:"payment_id"`
-	PaymentToken               *string       `json:"payment_token"`
-	Reference                  string        `json:"reference"`
-	Amount                     PaymentAmount `json:"amount"`
-	Status                     string        `json:"status"`
-	LastStatusUpdate           time.Time     `json:"last_status_update"`
-	PaymentTokenExpirationTime *time.Time    `json:"payment_token_expiration_time"`
-	RecipientID                string        `json:"recipient_id"`
+	PaymentID        string        `json:"payment_id"`
+	Reference        string        `json:"reference"`
+	Amount           PaymentAmount `json:"amount"`
+	Status           string        `json:"status"`
+	LastStatusUpdate time.Time     `json:"last_status_update"`
+	RecipientID      string        `json:"recipient_id"`
 }
 
 type GetPaymentResponse struct {

--- a/plaid/payment_test.go
+++ b/plaid/payment_test.go
@@ -107,19 +107,31 @@ func commonPaymentTestFlows(t *testing.T, recipientID string) {
 	paymentID := paymentCreateResp.PaymentID
 
 	paymentTokenCreateResp, err := testClient.CreatePaymentToken(paymentID)
+
+	linkTokenCreateResp, err := testClient.CreateLinkToken(LinkTokenConfigs{
+		User: &LinkTokenUser{
+			ClientUserID: time.Now().String(),
+		},
+		ClientName:   "Plaid Test",
+		Products:     []string{"auth"},
+		CountryCodes: []string{"US"},
+		Language:     "en",
+		PaymentInitiation: PaymentInitiation{
+			PaymentID: paymentID,
+		},
+	})
+
 	assert.Nil(t, err)
-	assert.NotNil(t, paymentTokenCreateResp.PaymentToken)
-	assert.NotNil(t, paymentTokenCreateResp.PaymentTokenExpirationTime)
+	assert.NotNil(t, linkTokenCreateResp.LinkToken)
+	assert.NotNil(t, linkTokenCreateResp.Expiration)
 
 	paymentGetResp, err := testClient.GetPayment(paymentCreateResp.PaymentID)
 	assert.Nil(t, err)
 	assert.NotNil(t, paymentGetResp.PaymentID)
-	assert.NotNil(t, paymentGetResp.PaymentToken)
 	assert.NotNil(t, paymentGetResp.Reference)
 	assert.NotNil(t, paymentGetResp.Amount)
 	assert.NotNil(t, paymentGetResp.Status)
 	assert.NotNil(t, paymentGetResp.LastStatusUpdate)
-	assert.NotNil(t, paymentGetResp.PaymentTokenExpirationTime)
 	assert.NotNil(t, paymentGetResp.RecipientID)
 
 	count := 10

--- a/plaid/payment_test.go
+++ b/plaid/payment_test.go
@@ -113,7 +113,7 @@ func commonPaymentTestFlows(t *testing.T, recipientID string) {
 			ClientUserID: time.Now().String(),
 		},
 		ClientName:   "Plaid Test",
-		Products:     []string{"auth"},
+		Products:     []string{"payment_initiation"},
 		CountryCodes: []string{"US"},
 		Language:     "en",
 		PaymentInitiation: PaymentInitiation{

--- a/plaid/payment_test.go
+++ b/plaid/payment_test.go
@@ -2,6 +2,7 @@ package plaid
 
 import (
 	"testing"
+	"time"
 
 	assert "github.com/stretchr/testify/require"
 )
@@ -106,8 +107,6 @@ func commonPaymentTestFlows(t *testing.T, recipientID string) {
 	assert.NotNil(t, paymentCreateResp.Status)
 	paymentID := paymentCreateResp.PaymentID
 
-	paymentTokenCreateResp, err := testClient.CreatePaymentToken(paymentID)
-
 	linkTokenCreateResp, err := testClient.CreateLinkToken(LinkTokenConfigs{
 		User: &LinkTokenUser{
 			ClientUserID: time.Now().String(),
@@ -116,7 +115,7 @@ func commonPaymentTestFlows(t *testing.T, recipientID string) {
 		Products:     []string{"payment_initiation"},
 		CountryCodes: []string{"US"},
 		Language:     "en",
-		PaymentInitiation: PaymentInitiation{
+		PaymentInitiation: &PaymentInitiation{
 			PaymentID: paymentID,
 		},
 	})

--- a/plaid/plaid.go
+++ b/plaid/plaid.go
@@ -12,7 +12,7 @@ import (
 )
 
 // APIVersion holds the latest version of the Plaid API
-const APIVersion = "2019-05-29"
+const APIVersion = "2020-09-14"
 
 // Client holds information required to interact with the Plaid API.
 // Note: Client is only exported for method documentation purposes.


### PR DESCRIPTION
1. Removed the legacy token implementations
2. Removed the tests associated with the legacy tokens
3. Updated tests to no longer check for the removed flag in the /item/remove response
4. Updated /payment/get test to no longer check for payment_token or payment_token_expiration_time