### PR TITLE
Add country codes to institutions/ endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,17 +27,17 @@ func main() {
 	handleError(err)
 
 	// POST /institutions/get
-	instsResp, err := client.GetInstitutions(5, 0)
+	instsResp, err := client.GetInstitutions(5, 0, []string{"US"})
 	handleError(err)
 	fmt.Println(instsResp.Institutions[0].Name, "has products:", instsResp.Institutions[0].Products)
 
 	// POST /institutions/get_by_id
-	instResp, err := client.GetInstitutionByID(instsResp.Institutions[0].ID)
+	instResp, err := client.GetInstitutionByID(instsResp.Institutions[0].ID, []string{"US"})
 	handleError(err)
 	fmt.Println(instResp.Institution.Name, "has MFA:", instResp.Institution.MFA)
 
 	// POST /institutions/search
-	instSearchResp, err := client.SearchInstitutions("Ally", []string{"transactions"})
+	instSearchResp, err := client.SearchInstitutions("Ally", []string{"transactions"}, []string{"US"})
 	handleError(err)
 	fmt.Println(instSearchResp.Institutions[0].Name, "has ID:", instSearchResp.Institutions[0].ID)
 

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -139,10 +139,6 @@ func (c *Client) GetInstitutionByIDWithOptions(
 		return resp, errors.New("/institutions/get_by_id - institution id must be specified")
 	}
 
-	if len(countryCodes) == 0 {
-		return resp, errors.New("/institutions/get_by_id - country codes must be specified")
-	}
-
 	jsonBody, err := json.Marshal(getInstitutionByIDRequest{
 		ID:           id,
 		CountryCodes: countryCodes,
@@ -175,10 +171,6 @@ func (c *Client) GetInstitutionsWithOptions(
 ) (resp GetInstitutionsResponse, err error) {
 	if count == 0 {
 		count = 50
-	}
-
-	if len(countryCodes) == 0 {
-		return resp, errors.New("/institutions/get - country codes must be specified")
 	}
 
 	jsonBody, err := json.Marshal(getInstitutionsRequest{
@@ -220,10 +212,6 @@ func (c *Client) SearchInstitutionsWithOptions(
 ) (resp SearchInstitutionsResponse, err error) {
 	if query == "" {
 		return resp, errors.New("/institutions/search - query must be specified")
-	}
-
-	if len(countryCodes) == 0 {
-		return resp, errors.New("/institutions/search - country codes must be specified")
 	}
 
 	jsonBody, err := json.Marshal(searchInstitutionsRequest{

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -61,17 +61,17 @@ type Credential struct {
 }
 
 type getInstitutionsRequest struct {
-	ClientID string                 `json:"client_id"`
-	Secret   string                 `json:"secret"`
-	Count    int                    `json:"count"`
-	Offset   int                    `json:"offset"`
-	Options  GetInstitutionsOptions `json:"options,omitempty"`
+	ClientID     string                 `json:"client_id"`
+	Secret       string                 `json:"secret"`
+	Count        int                    `json:"count"`
+	Offset       int                    `json:"offset"`
+	CountryCodes []string               `json:"country_codes"`
+	Options      GetInstitutionsOptions `json:"options,omitempty"`
 }
 
 type GetInstitutionsOptions struct {
 	Products                []string `json:"products"`
 	IncludeOptionalMetadata bool     `json:"include_optional_metadata"`
-	CountryCodes            []string `json:"country_codes"`
 	OAuth                   *bool    `json:"oauth"`
 }
 
@@ -82,10 +82,11 @@ type GetInstitutionsResponse struct {
 }
 
 type getInstitutionByIDRequest struct {
-	ID       string                    `json:"institution_id"`
-	ClientID string                    `json:"client_id"`
-	Secret   string                    `json:"secret"`
-	Options  GetInstitutionByIDOptions `json:"options,omitempty"`
+	ID           string                    `json:"institution_id"`
+	CountryCodes []string                  `json:"country_codes"`
+	ClientID     string                    `json:"client_id"`
+	Secret       string                    `json:"secret"`
+	Options      GetInstitutionByIDOptions `json:"options,omitempty"`
 }
 
 type GetInstitutionByIDOptions struct {
@@ -99,16 +100,16 @@ type GetInstitutionByIDResponse struct {
 }
 
 type searchInstitutionsRequest struct {
-	Query    string                    `json:"query"`
-	Products []string                  `json:"products"`
-	ClientID string                    `json:"client_id"`
-	Secret   string                    `json:"secret"`
-	Options  SearchInstitutionsOptions `json:"options,omitempty"`
+	Query        string                    `json:"query"`
+	CountryCodes []string                  `json:"country_codes"`
+	Products     []string                  `json:"products"`
+	ClientID     string                    `json:"client_id"`
+	Secret       string                    `json:"secret"`
+	Options      SearchInstitutionsOptions `json:"options,omitempty"`
 }
 
 type SearchInstitutionsOptions struct {
 	IncludeOptionalMetadata bool                   `json:"include_optional_metadata"`
-	CountryCodes            []string               `json:"country_codes"`
 	AccountFilter           map[string]interface{} `json:"account_filter"`
 	OAuth                   *bool                  `json:"oauth"`
 }
@@ -122,25 +123,32 @@ type SearchInstitutionsResponse struct {
 // See https://plaid.com/docs/api/#institutions-by-id.
 func (c *Client) GetInstitutionByID(
 	id string,
+	countryCodes []string,
 ) (resp GetInstitutionByIDResponse, err error) {
-	return c.GetInstitutionByIDWithOptions(id, GetInstitutionByIDOptions{})
+	return c.GetInstitutionByIDWithOptions(id, countryCodes, GetInstitutionByIDOptions{})
 }
 
 // GetInstitutionByIDWithOptions returns information for a single institution given an ID.
 // See https://plaid.com/docs/api/#institutions-by-id.
 func (c *Client) GetInstitutionByIDWithOptions(
 	id string,
+	countryCodes []string,
 	options GetInstitutionByIDOptions,
 ) (resp GetInstitutionByIDResponse, err error) {
 	if id == "" {
 		return resp, errors.New("/institutions/get_by_id - institution id must be specified")
 	}
 
+	if len(countryCodes) == 0 {
+		return resp, errors.New("/institutions/get_by_id - country codes must be specified")
+	}
+
 	jsonBody, err := json.Marshal(getInstitutionByIDRequest{
-		ID:       id,
-		ClientID: c.clientID,
-		Secret:   c.secret,
-		Options:  options,
+		ID:           id,
+		CountryCodes: countryCodes,
+		ClientID:     c.clientID,
+		Secret:       c.secret,
+		Options:      options,
 	})
 
 	if err != nil {
@@ -153,8 +161,8 @@ func (c *Client) GetInstitutionByIDWithOptions(
 
 // GetInstitutions returns information for all institutions supported by Plaid.
 // See https://plaid.com/docs/api/#all-institutions.
-func (c *Client) GetInstitutions(count, offset int) (resp GetInstitutionsResponse, err error) {
-	return c.GetInstitutionsWithOptions(count, offset, GetInstitutionsOptions{})
+func (c *Client) GetInstitutions(count, offset int, countryCodes []string) (resp GetInstitutionsResponse, err error) {
+	return c.GetInstitutionsWithOptions(count, offset, countryCodes, GetInstitutionsOptions{})
 }
 
 // GetInstitutionsWithOptions returns information for all institutions supported by Plaid.
@@ -162,18 +170,24 @@ func (c *Client) GetInstitutions(count, offset int) (resp GetInstitutionsRespons
 func (c *Client) GetInstitutionsWithOptions(
 	count int,
 	offset int,
+	countryCodes []string,
 	options GetInstitutionsOptions,
 ) (resp GetInstitutionsResponse, err error) {
 	if count == 0 {
 		count = 50
 	}
 
+	if len(countryCodes) == 0 {
+		return resp, errors.New("/institutions/get - country codes must be specified")
+	}
+
 	jsonBody, err := json.Marshal(getInstitutionsRequest{
-		ClientID: c.clientID,
-		Secret:   c.secret,
-		Count:    count,
-		Offset:   offset,
-		Options:  options,
+		ClientID:     c.clientID,
+		Secret:       c.secret,
+		Count:        count,
+		Offset:       offset,
+		CountryCodes: countryCodes,
+		Options:      options,
 	})
 
 	if err != nil {
@@ -190,8 +204,9 @@ func (c *Client) GetInstitutionsWithOptions(
 func (c *Client) SearchInstitutions(
 	query string,
 	products []string,
+	countryCodes []string,
 ) (resp SearchInstitutionsResponse, err error) {
-	return c.SearchInstitutionsWithOptions(query, products, SearchInstitutionsOptions{})
+	return c.SearchInstitutionsWithOptions(query, products, countryCodes, SearchInstitutionsOptions{})
 }
 
 // SearchInstitutionsWithOptions returns institutions corresponding to a query string and
@@ -200,18 +215,24 @@ func (c *Client) SearchInstitutions(
 func (c *Client) SearchInstitutionsWithOptions(
 	query string,
 	products []string,
+	countryCodes []string,
 	options SearchInstitutionsOptions,
 ) (resp SearchInstitutionsResponse, err error) {
 	if query == "" {
 		return resp, errors.New("/institutions/search - query must be specified")
 	}
 
+	if len(countryCodes) == 0 {
+		return resp, errors.New("/institutions/search - country codes must be specified")
+	}
+
 	jsonBody, err := json.Marshal(searchInstitutionsRequest{
-		Query:    query,
-		Products: products,
-		ClientID: c.clientID,
-		Secret:   c.secret,
-		Options:  options,
+		Query:        query,
+		Products:     products,
+		CountryCodes: countryCodes,
+		ClientID:     c.clientID,
+		Secret:       c.secret,
+		Options:      options,
 	})
 
 	if err != nil {

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -13,13 +13,14 @@ func TestGetInstitutions(t *testing.T) {
 	for _, options := range []GetInstitutionsOptions{
 		GetInstitutionsOptions{},
 		GetInstitutionsOptions{IncludeOptionalMetadata: true},
-		GetInstitutionsOptions{
-			CountryCodes: []string{"GB"},
-			OAuth:        &oauthTrue,
-		},
+		GetInstitutionsOptions{OAuth: &oauthTrue},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
-			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, options)
+			countryCodes := []string{"US"}
+			if options.OAuth == true {
+				countryCodes = []string["GB"]
+			}
+			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, countryCodes, options)
 			assert.Nil(t, err)
 
 			assert.Len(t, instsResp.Institutions, 2)
@@ -46,13 +47,16 @@ func TestSearchInstitutions(t *testing.T) {
 		SearchInstitutionsOptions{},
 		SearchInstitutionsOptions{IncludeOptionalMetadata: true},
 		SearchInstitutionsOptions{
-			CountryCodes: []string{"GB"},
 			OAuth:        &oauthTrue,
 		},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			p := []string{"transactions"}
-			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, options)
+			countryCodes := []string{"US"}
+			if options.OAuth == true {
+				countryCodes = []string["GB"]
+			}
+			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, countryCodes, options)
 			assert.Nil(t, err)
 			assert.True(t, len(instsResp.Institutions) > 0)
 
@@ -78,8 +82,8 @@ func TestGetInstitutionsByID(t *testing.T) {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			// can't use the normal sandbox institution because it only returns the ItemLogins status.
 			institutionID := "ins_12"
-
-			instResp, err := testClient.GetInstitutionByIDWithOptions(institutionID, options)
+			countryCodes := []string{"US"}
+			instResp, err := testClient.GetInstitutionByIDWithOptions(institutionID, countryCodes, options)
 			assert.Nil(t, err)
 			assert.True(t, len(instResp.Institution.Products) > 0)
 

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -17,7 +17,7 @@ func TestGetInstitutions(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			countryCodes := []string{"US"}
-			if *options.OAuth == true {
+			if options.OAuth != nil && *options.OAuth == true {
 				countryCodes = []string{"GB"}
 			}
 			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, countryCodes, options)
@@ -53,7 +53,7 @@ func TestSearchInstitutions(t *testing.T) {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			p := []string{"transactions"}
 			countryCodes := []string{"US"}
-			if *options.OAuth == true {
+			if options.OAuth != nil && *options.OAuth == true {
 				countryCodes = []string{"GB"}
 			}
 			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, countryCodes, options)

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -48,14 +48,14 @@ func TestGetInstitutions(t *testing.T) {
 					assert.NotEmpty(t, inst.Name)
 				}
 
-				if options.IncludeOptionalMetadata {
+				if tc.options.IncludeOptionalMetadata {
 					for _, inst := range instsResp.Institutions {
 						assert.NotEmpty(t, inst.URL)
 					}
 				}
-				if options.OAuth != nil {
+				if tc.options.OAuth != nil {
 					for _, inst := range instsResp.Institutions {
-						assert.Equal(t, inst.OAuth, *options.OAuth)
+						assert.Equal(t, inst.OAuth, *tc.options.OAuth)
 					}
 				}
 			}
@@ -100,14 +100,14 @@ func TestSearchInstitutions(t *testing.T) {
 				assert.Nil(t, err)
 				assert.True(t, len(instsResp.Institutions) > 0)
 
-				if options.IncludeOptionalMetadata {
+				if tc.options.IncludeOptionalMetadata {
 					for _, inst := range instsResp.Institutions {
 						assert.NotEmpty(t, inst.URL)
 					}
 				}
-				if options.OAuth != nil {
+				if tc.options.OAuth != nil {
 					for _, inst := range instsResp.Institutions {
-						assert.Equal(t, inst.OAuth, *options.OAuth)
+						assert.Equal(t, inst.OAuth, *tc.options.OAuth)
 					}
 				}
 			}
@@ -151,7 +151,7 @@ func TestGetInstitutionsByID(t *testing.T) {
 				assert.Nil(t, err)
 				assert.True(t, len(instResp.Institution.Products) > 0)
 
-				if options.IncludeOptionalMetadata {
+				if tc.options.IncludeOptionalMetadata {
 					assert.NotEmpty(t, instResp.Institution.URL)
 				}
 			}

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -17,7 +17,7 @@ func TestGetInstitutions(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			countryCodes := []string{"US"}
-			if options.OAuth == true {
+			if *options.OAuth == true {
 				countryCodes = []string{"GB"}
 			}
 			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, countryCodes, options)
@@ -47,13 +47,13 @@ func TestSearchInstitutions(t *testing.T) {
 		SearchInstitutionsOptions{},
 		SearchInstitutionsOptions{IncludeOptionalMetadata: true},
 		SearchInstitutionsOptions{
-			OAuth:        &oauthTrue,
+			OAuth: &oauthTrue,
 		},
 	} {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			p := []string{"transactions"}
 			countryCodes := []string{"US"}
-			if options.OAuth == true {
+			if *options.OAuth == true {
 				countryCodes = []string{"GB"}
 			}
 			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, countryCodes, options)

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -18,7 +18,7 @@ func TestGetInstitutions(t *testing.T) {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			countryCodes := []string{"US"}
 			if options.OAuth == true {
-				countryCodes = []string["GB"]
+				countryCodes = []string{"GB"}
 			}
 			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, countryCodes, options)
 			assert.Nil(t, err)
@@ -54,7 +54,7 @@ func TestSearchInstitutions(t *testing.T) {
 			p := []string{"transactions"}
 			countryCodes := []string{"US"}
 			if options.OAuth == true {
-				countryCodes = []string["GB"]
+				countryCodes = []string{"GB"}
 			}
 			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, countryCodes, options)
 			assert.Nil(t, err)

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -1,7 +1,6 @@
 package plaid
 
 import (
-	"fmt"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -37,8 +36,8 @@ func TestGetInstitutions(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
-			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, tc.countryCodes, options)
+		t.Run(tc.desc, func(t *testing.T) {
+			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, tc.countryCodes, tc.options)
 			if len(tc.countryCodes) == 0 {
 				assert.NotNil(t, err)
 			} else {
@@ -92,9 +91,9 @@ func TestSearchInstitutions(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			p := []string{"transactions"}
-			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, tc.countryCodes, options)
+			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, tc.countryCodes, tc.options)
 			if len(tc.countryCodes) == 0 {
 				assert.NotNil(t, err)
 			} else {
@@ -142,10 +141,10 @@ func TestGetInstitutionsByID(t *testing.T) {
 		GetInstitutionByIDOptions{},
 		GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
 	} {
-		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			// can't use the normal sandbox institution because it only returns the ItemLogins status.
 			institutionID := "ins_12"
-			instResp, err := testClient.GetInstitutionByIDWithOptions(institutionID, tc.countryCodes, options)
+			instResp, err := testClient.GetInstitutionByIDWithOptions(institutionID, tc.countryCodes, tc.options)
 			if len(tc.countryCodes) == 0 {
 				assert.NotNil(t, err)
 			} else {

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -137,10 +137,7 @@ func TestGetInstitutionsByID(t *testing.T) {
 			options:      GetInstitutionByIDOptions{},
 		},
 	}
-	for _, options := range []GetInstitutionByIDOptions{
-		GetInstitutionByIDOptions{},
-		GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
-	} {
+	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			// can't use the normal sandbox institution because it only returns the ItemLogins status.
 			institutionID := "ins_12"

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -11,35 +11,35 @@ var oauthTrue = true
 
 func TestGetInstitutions(t *testing.T) {
 	testCases := []struct {
-		desc string
+		desc         string
 		countryCodes []string
-		options GetInstitutionsOptions
+		options      GetInstitutionsOptions
 	}{
 		{
-			desc: "succeeds without options",
+			desc:         "succeeds without options",
 			countryCodes: []string{"US"},
-			options: GetInstitutionsOptions{},
+			options:      GetInstitutionsOptions{},
 		},
 		{
-			desc: "succeeds with optional metadata",
+			desc:         "succeeds with optional metadata",
 			countryCodes: []string{"US"},
-			options: GetInstitutionsOptions{IncludeOptionalMetadata: true},
+			options:      GetInstitutionsOptions{IncludeOptionalMetadata: true},
 		},
 		{
-			desc: "succeeds for oauth institutions",
+			desc:         "succeeds for oauth institutions",
 			countryCodes: []string{"GB"},
-			options: GetInstitutionsOptions{OAuth: &oauthTrue},
+			options:      GetInstitutionsOptions{OAuth: &oauthTrue},
 		},
 		{
-			desc: "errors without country codes",
+			desc:         "errors without country codes",
 			countryCodes: []string{},
-			options: GetInstitutionsOptions{},
-		}
+			options:      GetInstitutionsOptions{},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, tc.countryCodes, options)
-			if (len(tc.countryCodes) == 0){
+			if len(tc.countryCodes) == 0 {
 				assert.NotNil(t, err)
 			} else {
 				assert.Nil(t, err)
@@ -66,36 +66,36 @@ func TestGetInstitutions(t *testing.T) {
 
 func TestSearchInstitutions(t *testing.T) {
 	testCases := []struct {
-		desc string
+		desc         string
 		countryCodes []string
-		options SearchInstitutionsOptions
+		options      SearchInstitutionsOptions
 	}{
 		{
-			desc: "succeeds without options",
+			desc:         "succeeds without options",
 			countryCodes: []string{"US"},
-			options: SearchInstitutionsOptions{},
+			options:      SearchInstitutionsOptions{},
 		},
 		{
-			desc: "succeeds with optional metadata",
+			desc:         "succeeds with optional metadata",
 			countryCodes: []string{"US"},
-			options: SearchInstitutionsOptions{IncludeOptionalMetadata: true},
+			options:      SearchInstitutionsOptions{IncludeOptionalMetadata: true},
 		},
 		{
-			desc: "succeeds for oauth institutions",
+			desc:         "succeeds for oauth institutions",
 			countryCodes: []string{"GB"},
-			options: SearchInstitutionsOptions{OAuth: &oauthTrue},
+			options:      SearchInstitutionsOptions{OAuth: &oauthTrue},
 		},
 		{
-			desc: "errors without country codes",
+			desc:         "errors without country codes",
 			countryCodes: []string{},
-			options: SearchInstitutionsOptions{},
-		}
+			options:      SearchInstitutionsOptions{},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			p := []string{"transactions"}
 			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, tc.countryCodes, options)
-			if (len(tc.countryCodes) == 0){
+			if len(tc.countryCodes) == 0 {
 				assert.NotNil(t, err)
 			} else {
 				assert.Nil(t, err)
@@ -118,25 +118,25 @@ func TestSearchInstitutions(t *testing.T) {
 
 func TestGetInstitutionsByID(t *testing.T) {
 	testCases := []struct {
-		desc string
+		desc         string
 		countryCodes []string
-		options GetInstitutionByIDOptions
+		options      GetInstitutionByIDOptions
 	}{
 		{
-			desc: "succeeds without options",
+			desc:         "succeeds without options",
 			countryCodes: []string{"US"},
-			options: GetInstitutionByIDOptions{},
+			options:      GetInstitutionByIDOptions{},
 		},
 		{
-			desc: "succeeds with optional metadata",
+			desc:         "succeeds with optional metadata",
 			countryCodes: []string{"US"},
-			options: GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
+			options:      GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
 		},
 		{
-			desc: "errors without country codes",
+			desc:         "errors without country codes",
 			countryCodes: []string{},
-			options: GetInstitutionByIDOptions{},
-		}
+			options:      GetInstitutionByIDOptions{},
+		},
 	}
 	for _, options := range []GetInstitutionByIDOptions{
 		GetInstitutionByIDOptions{},
@@ -146,7 +146,7 @@ func TestGetInstitutionsByID(t *testing.T) {
 			// can't use the normal sandbox institution because it only returns the ItemLogins status.
 			institutionID := "ins_12"
 			instResp, err := testClient.GetInstitutionByIDWithOptions(institutionID, tc.countryCodes, options)
-			if (len(tc.countryCodes) == 0){
+			if len(tc.countryCodes) == 0 {
 				assert.NotNil(t, err)
 			} else {
 				assert.Nil(t, err)

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -10,32 +10,54 @@ import (
 var oauthTrue = true
 
 func TestGetInstitutions(t *testing.T) {
-	for _, options := range []GetInstitutionsOptions{
-		GetInstitutionsOptions{},
-		GetInstitutionsOptions{IncludeOptionalMetadata: true},
-		GetInstitutionsOptions{OAuth: &oauthTrue},
-	} {
+	testCases := []struct {
+		desc string
+		countryCodes []string
+		options GetInstitutionsOptions
+	}{
+		{
+			desc: "succeeds without options",
+			countryCodes: []string{"US"},
+			options: GetInstitutionsOptions{},
+		},
+		{
+			desc: "succeeds with optional metadata",
+			countryCodes: []string{"US"},
+			options: GetInstitutionsOptions{IncludeOptionalMetadata: true},
+		},
+		{
+			desc: "succeeds for oauth institutions",
+			countryCodes: []string{"GB"},
+			options: GetInstitutionsOptions{OAuth: &oauthTrue},
+		},
+		{
+			desc: "errors without country codes",
+			countryCodes: []string{},
+			options: GetInstitutionsOptions{},
+		}
+	}
+	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
-			countryCodes := []string{"US"}
-			if options.OAuth != nil && *options.OAuth == true {
-				countryCodes = []string{"GB"}
-			}
-			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, countryCodes, options)
-			assert.Nil(t, err)
+			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, tc.countryCodes, options)
+			if (len(tc.countryCodes) == 0){
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
 
-			assert.Len(t, instsResp.Institutions, 2)
-			for _, inst := range instsResp.Institutions {
-				assert.NotEmpty(t, inst.Name)
-			}
-
-			if options.IncludeOptionalMetadata {
+				assert.Len(t, instsResp.Institutions, 2)
 				for _, inst := range instsResp.Institutions {
-					assert.NotEmpty(t, inst.URL)
+					assert.NotEmpty(t, inst.Name)
 				}
-			}
-			if options.OAuth != nil {
-				for _, inst := range instsResp.Institutions {
-					assert.Equal(t, inst.OAuth, *options.OAuth)
+
+				if options.IncludeOptionalMetadata {
+					for _, inst := range instsResp.Institutions {
+						assert.NotEmpty(t, inst.URL)
+					}
+				}
+				if options.OAuth != nil {
+					for _, inst := range instsResp.Institutions {
+						assert.Equal(t, inst.OAuth, *options.OAuth)
+					}
 				}
 			}
 		})
@@ -43,31 +65,51 @@ func TestGetInstitutions(t *testing.T) {
 }
 
 func TestSearchInstitutions(t *testing.T) {
-	for _, options := range []SearchInstitutionsOptions{
-		SearchInstitutionsOptions{},
-		SearchInstitutionsOptions{IncludeOptionalMetadata: true},
-		SearchInstitutionsOptions{
-			OAuth: &oauthTrue,
+	testCases := []struct {
+		desc string
+		countryCodes []string
+		options SearchInstitutionsOptions
+	}{
+		{
+			desc: "succeeds without options",
+			countryCodes: []string{"US"},
+			options: SearchInstitutionsOptions{},
 		},
-	} {
+		{
+			desc: "succeeds with optional metadata",
+			countryCodes: []string{"US"},
+			options: SearchInstitutionsOptions{IncludeOptionalMetadata: true},
+		},
+		{
+			desc: "succeeds for oauth institutions",
+			countryCodes: []string{"GB"},
+			options: SearchInstitutionsOptions{OAuth: &oauthTrue},
+		},
+		{
+			desc: "errors without country codes",
+			countryCodes: []string{},
+			options: SearchInstitutionsOptions{},
+		}
+	}
+	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			p := []string{"transactions"}
-			countryCodes := []string{"US"}
-			if options.OAuth != nil && *options.OAuth == true {
-				countryCodes = []string{"GB"}
-			}
-			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, countryCodes, options)
-			assert.Nil(t, err)
-			assert.True(t, len(instsResp.Institutions) > 0)
+			instsResp, err := testClient.SearchInstitutionsWithOptions(sandboxInstitutionQuery, p, tc.countryCodes, options)
+			if (len(tc.countryCodes) == 0){
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.True(t, len(instsResp.Institutions) > 0)
 
-			if options.IncludeOptionalMetadata {
-				for _, inst := range instsResp.Institutions {
-					assert.NotEmpty(t, inst.URL)
+				if options.IncludeOptionalMetadata {
+					for _, inst := range instsResp.Institutions {
+						assert.NotEmpty(t, inst.URL)
+					}
 				}
-			}
-			if options.OAuth != nil {
-				for _, inst := range instsResp.Institutions {
-					assert.Equal(t, inst.OAuth, *options.OAuth)
+				if options.OAuth != nil {
+					for _, inst := range instsResp.Institutions {
+						assert.Equal(t, inst.OAuth, *options.OAuth)
+					}
 				}
 			}
 		})
@@ -75,6 +117,27 @@ func TestSearchInstitutions(t *testing.T) {
 }
 
 func TestGetInstitutionsByID(t *testing.T) {
+	testCases := []struct {
+		desc string
+		countryCodes []string
+		options GetInstitutionByIDOptions
+	}{
+		{
+			desc: "succeeds without options",
+			countryCodes: []string{"US"},
+			options: GetInstitutionByIDOptions{},
+		},
+		{
+			desc: "succeeds with optional metadata",
+			countryCodes: []string{"US"},
+			options: GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
+		},
+		{
+			desc: "errors without country codes",
+			countryCodes: []string{},
+			options: GetInstitutionByIDOptions{},
+		}
+	}
 	for _, options := range []GetInstitutionByIDOptions{
 		GetInstitutionByIDOptions{},
 		GetInstitutionByIDOptions{IncludeOptionalMetadata: true},
@@ -82,13 +145,16 @@ func TestGetInstitutionsByID(t *testing.T) {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
 			// can't use the normal sandbox institution because it only returns the ItemLogins status.
 			institutionID := "ins_12"
-			countryCodes := []string{"US"}
-			instResp, err := testClient.GetInstitutionByIDWithOptions(institutionID, countryCodes, options)
-			assert.Nil(t, err)
-			assert.True(t, len(instResp.Institution.Products) > 0)
+			instResp, err := testClient.GetInstitutionByIDWithOptions(institutionID, tc.countryCodes, options)
+			if (len(tc.countryCodes) == 0){
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.True(t, len(instResp.Institution.Products) > 0)
 
-			if options.IncludeOptionalMetadata {
-				assert.NotEmpty(t, instResp.Institution.URL)
+				if options.IncludeOptionalMetadata {
+					assert.NotEmpty(t, instResp.Institution.URL)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Country codes are now required for the /institutions/ API endpoints. This updates the client library to properly take a country_codes field