### PR TITLE
Add Routing Numbers to Institutions

### DIFF
--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -15,7 +15,7 @@ type Institution struct {
 	Products       []string     `json:"products"`
 	CountryCodes   []string     `json:"country_codes"`
 	OAuth          bool         `json:"oauth"`
-	RoutingNumbers []string     `json:"routing_numbers,omitempty"`
+	RoutingNumbers []string     `json:"routing_numbers"`
 
 	// Included when `options.include_status` is true.
 	InstitutionStatus *InstitutionStatus `json:"status,omitempty"`

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -7,14 +7,15 @@ import (
 )
 
 type Institution struct {
-	Credentials  []Credential `json:"credentials"`
-	HasMFA       bool         `json:"has_mfa"`
-	ID           string       `json:"institution_id"`
-	MFA          []string     `json:"mfa"`
-	Name         string       `json:"name"`
-	Products     []string     `json:"products"`
-	CountryCodes []string     `json:"country_codes"`
-	OAuth        bool         `json:"oauth"`
+	Credentials    []Credential `json:"credentials"`
+	HasMFA         bool         `json:"has_mfa"`
+	ID             string       `json:"institution_id"`
+	MFA            []string     `json:"mfa"`
+	Name           string       `json:"name"`
+	Products       []string     `json:"products"`
+	CountryCodes   []string     `json:"country_codes"`
+	OAuth          bool         `json:"oauth"`
+	RoutingNumbers []string     `json:"routing_numbers,omitempty"`
 
 	// Included when `options.include_status` is true.
 	InstitutionStatus *InstitutionStatus `json:"status,omitempty"`
@@ -73,6 +74,7 @@ type GetInstitutionsOptions struct {
 	IncludeOptionalMetadata bool     `json:"include_optional_metadata"`
 	CountryCodes            []string `json:"country_codes"`
 	OAuth                   *bool    `json:"oauth"`
+	RoutingNumbers          []string `json:"routing_numbers"`
 }
 
 type GetInstitutionsResponse struct {

--- a/plaid/institutions_test.go
+++ b/plaid/institutions_test.go
@@ -12,38 +12,63 @@ func TestGetInstitutions(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		countryCodes []string
+		count        int
+		offset       int
 		options      GetInstitutionsOptions
+		wantLength   int // expected length of results
 	}{
 		{
 			desc:         "succeeds without options",
 			countryCodes: []string{"US"},
+			count:        2,
+			offset:       1,
 			options:      GetInstitutionsOptions{},
+			wantLength:   2,
 		},
 		{
 			desc:         "succeeds with optional metadata",
 			countryCodes: []string{"US"},
+			count:        2,
+			offset:       1,
 			options:      GetInstitutionsOptions{IncludeOptionalMetadata: true},
+			wantLength:   2,
 		},
 		{
 			desc:         "succeeds for oauth institutions",
 			countryCodes: []string{"GB"},
+			count:        2,
+			offset:       1,
 			options:      GetInstitutionsOptions{OAuth: &oauthTrue},
+			wantLength:   2,
 		},
 		{
 			desc:         "errors without country codes",
 			countryCodes: []string{},
+			count:        2,
+			offset:       1,
 			options:      GetInstitutionsOptions{},
+			wantLength:   0,
+		},
+		{
+			desc:         "succeeds with routing numbers",
+			countryCodes: []string{"US"},
+			count:        1,
+			offset:       0,
+			options: GetInstitutionsOptions{
+				RoutingNumbers: []string{"021200339", "052001633"},
+			},
+			wantLength: 1,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			instsResp, err := testClient.GetInstitutionsWithOptions(2, 1, tc.countryCodes, tc.options)
+			instsResp, err := testClient.GetInstitutionsWithOptions(tc.count, tc.offset, tc.countryCodes, tc.options)
 			if len(tc.countryCodes) == 0 {
 				assert.NotNil(t, err)
 			} else {
 				assert.Nil(t, err)
 
-				assert.Len(t, instsResp.Institutions, 2)
+				assert.Len(t, instsResp.Institutions, tc.wantLength)
 				for _, inst := range instsResp.Institutions {
 					assert.NotEmpty(t, inst.Name)
 				}


### PR DESCRIPTION
Here's a PR for issue #132 I opened a few months ago. I see that @skylarmb had started on this with #140, so if you'd rather finish that up and merge that one, that works for me.

- Adds `RoutingNumbers` field to `Institutions` and `GetInstitutionsOptions` structs
- Edits `TestGetInstitutions` to use a table format to make it easier to have multiple subtests
- Adds a subtest in `TestGetInstitutions` to test specifying routing numbers in the request
- Resolves #132