### PR TITLE
add back legacy token endpoints but mark them as deprecated

### DIFF
--- a/plaid/item.go
+++ b/plaid/item.go
@@ -89,22 +89,6 @@ type CreatePublicTokenResponse struct {
 	PublicToken string `json:"public_token"`
 }
 
-type createItemAddTokenRequest struct {
-	ClientID   string                 `json:"client_id"`
-	Secret     string                 `json:"secret"`
-	UserFields ItemAddTokenUserFields `json:"user"`
-}
-
-type ItemAddTokenUserFields struct {
-	ClientUserID string `json:"client_user_id"`
-}
-
-type CreateItemAddTokenResponse struct {
-	APIResponse
-	AddToken   string    `json:"add_token"`
-	Expiration time.Time `json:"expiration"`
-}
-
 type exchangePublicTokenRequest struct {
 	ClientID    string `json:"client_id"`
 	Secret      string `json:"secret"`
@@ -241,24 +225,6 @@ func (c *Client) CreatePublicToken(accessToken string) (resp CreatePublicTokenRe
 	}
 
 	err = c.Call("/item/public_token/create", jsonBody, &resp)
-	return resp, err
-}
-
-// CreateItemAddToken generates a token which is used to initialize Link.
-func (c *Client) CreateItemAddToken(userFields ItemAddTokenUserFields) (resp CreateItemAddTokenResponse, err error) {
-	fmt.Println("Warning: this method will be deprecated in a future version. To replace the item_add_token, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.")
-
-	jsonBody, err := json.Marshal(createItemAddTokenRequest{
-		ClientID:   c.clientID,
-		Secret:     c.secret,
-		UserFields: userFields,
-	})
-
-	if err != nil {
-		return resp, err
-	}
-
-	err = c.Call("/item/add_token/create", jsonBody, &resp)
 	return resp, err
 }
 

--- a/plaid/item.go
+++ b/plaid/item.go
@@ -3,6 +3,7 @@ package plaid
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -223,6 +224,8 @@ func (c *Client) InvalidateAccessToken(accessToken string) (resp InvalidateAcces
 // 30 minutes to update an Item.
 // See https://plaid.com/docs/api/#creating-public-tokens.
 func (c *Client) CreatePublicToken(accessToken string) (resp CreatePublicTokenResponse, err error) {
+	fmt.Println("Warning: this method will be deprecated in a future version. To replace the public_token for initializing Link, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.")
+
 	if accessToken == "" {
 		return resp, errors.New("/item/public_token/create - access token must be specified")
 	}
@@ -243,9 +246,8 @@ func (c *Client) CreatePublicToken(accessToken string) (resp CreatePublicTokenRe
 
 // CreateItemAddToken generates a token which is used to initialize Link.
 func (c *Client) CreateItemAddToken(userFields ItemAddTokenUserFields) (resp CreateItemAddTokenResponse, err error) {
-	// TODO - Print out message indicating that this endpoints is deprecated
-	// and will be removed in a future version. It should also say to look
-	// into the /link/token/create endpoint instead.
+	fmt.Println("Warning: this method will be deprecated in a future version. To replace the item_add_token, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.")
+
 	jsonBody, err := json.Marshal(createItemAddTokenRequest{
 		ClientID:   c.clientID,
 		Secret:     c.secret,

--- a/plaid/item_test.go
+++ b/plaid/item_test.go
@@ -62,17 +62,6 @@ func TestCreatePublicToken(t *testing.T) {
 	assert.True(t, strings.HasPrefix(publicTokenResp.PublicToken, "public-sandbox"))
 }
 
-func TestCreateItemAddToken(t *testing.T) {
-	fakeClientUserID, _ := randomHex(12)
-	itemAddTokenResp, err := testClient.CreateItemAddToken(ItemAddTokenUserFields{
-		ClientUserID: fakeClientUserID,
-	})
-
-	assert.Nil(t, err)
-	assert.True(t, strings.HasPrefix(itemAddTokenResp.AddToken, "item-add-sandbox"))
-	assert.NotZero(t, itemAddTokenResp.Expiration)
-}
-
 func TestExchangePublicToken(t *testing.T) {
 	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
 	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)

--- a/plaid/item_test.go
+++ b/plaid/item_test.go
@@ -53,6 +53,26 @@ func TestInvalidateAccessToken(t *testing.T) {
 	assert.NotEmpty(t, newTokenResp.NewAccessToken)
 }
 
+func TestCreatePublicToken(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+	publicTokenResp, err := testClient.CreatePublicToken(tokenResp.AccessToken)
+
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(publicTokenResp.PublicToken, "public-sandbox"))
+}
+
+func TestCreateItemAddToken(t *testing.T) {
+	fakeClientUserID, _ := randomHex(12)
+	itemAddTokenResp, err := testClient.CreateItemAddToken(ItemAddTokenUserFields{
+		ClientUserID: fakeClientUserID,
+	})
+
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(itemAddTokenResp.AddToken, "item-add-sandbox"))
+	assert.NotZero(t, itemAddTokenResp.Expiration)
+}
+
 func TestExchangePublicToken(t *testing.T) {
 	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
 	tokenResp, err := testClient.ExchangePublicToken(sandboxResp.PublicToken)

--- a/plaid/payment.go
+++ b/plaid/payment.go
@@ -2,6 +2,7 @@ package plaid
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -172,6 +173,8 @@ type CreatePaymentTokenResponse struct {
 func (c *Client) CreatePaymentToken(
 	paymentID string,
 ) (resp CreatePaymentTokenResponse, err error) {
+	fmt.Println("Warning: this method will be deprecated in a future version. To replace the payment_token, look into the link_token at https://plaid.com/docs/api/tokens/#linktokencreate.")
+
 	jsonBody, err := json.Marshal(createPaymentTokenRequest{
 		ClientID:  c.clientID,
 		Secret:    c.secret,

--- a/plaid/payment.go
+++ b/plaid/payment.go
@@ -157,6 +157,34 @@ func (c *Client) CreatePayment(
 	return resp, err
 }
 
+type createPaymentTokenRequest struct {
+	ClientID  string `json:"client_id"`
+	Secret    string `json:"secret"`
+	PaymentID string `json:"payment_id"`
+}
+
+type CreatePaymentTokenResponse struct {
+	APIResponse
+	PaymentToken               string    `json:"payment_token"`
+	PaymentTokenExpirationTime time.Time `json:"payment_token_expiration_time"`
+}
+
+func (c *Client) CreatePaymentToken(
+	paymentID string,
+) (resp CreatePaymentTokenResponse, err error) {
+	jsonBody, err := json.Marshal(createPaymentTokenRequest{
+		ClientID:  c.clientID,
+		Secret:    c.secret,
+		PaymentID: paymentID,
+	})
+	if err != nil {
+		return resp, err
+	}
+
+	err = c.Call("/payment_initiation/payment/token/create", jsonBody, &resp)
+	return resp, err
+}
+
 type getPaymentRequest struct {
 	ClientID  string `json:"client_id"`
 	Secret    string `json:"secret"`


### PR DESCRIPTION
Add back support for the legacy token create endpoints but mark them as deprecated since we advise new client library users from using them. They will be supported in this version but will eventually be eventually be removed for real in some future version.

- /item/public_token/create
- /item/add_token/create
- /payment_initiation/payment/token/create