### PR TITLE
Adds payment_initiation metadata support

### DIFF
--- a/plaid/api_test.go
+++ b/plaid/api_test.go
@@ -11,9 +11,11 @@ var (
 	testSecret   = os.Getenv("PLAID_SECRET")
 	testEnv      = Sandbox
 
-	sandboxInstitution      = "ins_109508"
-	sandboxInstitutionQuery = "Platypus"
-	testProducts            = []string{"auth", "identity", "transactions"}
+	sandboxInstitution                               = "ins_109508"
+	sandboxInstitutionQuery                          = "Platypus"
+	paymentInitiationMetadataSandboxInstitution      = "ins_117650"
+	paymentInitiationMetadataSandboxInstitutionQuery = "Royal Bank of Plaid"
+	testProducts                                     = []string{"auth", "identity", "transactions"}
 )
 
 var testOptions = ClientOptions{

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -26,15 +26,31 @@ type Institution struct {
 	URL string `json:"url,omitempty"`
 	// Included when `options.include_optional_metadata` is true.
 	Logo string `json:"logo,omitempty"`
+
+	// Included when `options.include_payment_initiation_metadata` is true.
+	PaymentInitiationMetadata *PaymentInitiationMetadata `json:"payment_initiation_metadata,omitempty"`
+}
+
+type PaymentInitiationMetadata struct {
+	MaximumPaymentAmount          map[string]string      `json:"maximum_payment_amount"`
+	StandingOrderMetadata         *StandingOrderMetadata `json:"standing_order_metadata"`
+	SupportsInternationalPayments bool                   `json:"supports_international_payments"`
+	SupportsRefundDetails         bool                   `json:"supports_refund_details"`
+}
+
+type StandingOrderMetadata struct {
+	SupportsStandingOrderEndDate               bool     `json:"supports_standing_order_end_date"`
+	SupportsStandingOrderNegativeExecutionDays bool     `json:"supports_standing_order_negative_execution_days"`
+	ValidStandingOrderIntervals                []string `json:"valid_standing_order_intervals"`
 }
 
 type InstitutionStatus struct {
-	ItemLogins          ItemLogins                       `json:"item_logins"`
-	TransactionsUpdates InstitutionStatusFields          `json:"transactions_updates"`
-	Auth                InstitutionStatusFields          `json:"auth"`
-	Balance             InstitutionStatusFields          `json:"balance"`
-	Identity            InstitutionStatusFields          `json:"identity"`
-	InvestmentUpdates   InstitutionStatusFields          `json:"investments_updates"`
+	ItemLogins          ItemLogins                        `json:"item_logins"`
+	TransactionsUpdates InstitutionStatusFields           `json:"transactions_updates"`
+	Auth                InstitutionStatusFields           `json:"auth"`
+	Balance             InstitutionStatusFields           `json:"balance"`
+	Identity            InstitutionStatusFields           `json:"identity"`
+	InvestmentUpdates   InstitutionStatusFields           `json:"investments_updates"`
 	HealthIncidents     []InstitutionStatusHealthIncident `json:"health_incidents"`
 }
 
@@ -86,10 +102,16 @@ type getInstitutionsRequest struct {
 }
 
 type GetInstitutionsOptions struct {
-	Products                []string `json:"products"`
-	IncludeOptionalMetadata bool     `json:"include_optional_metadata"`
-	OAuth                   *bool    `json:"oauth"`
-	RoutingNumbers          []string `json:"routing_numbers"`
+	Products                         []string                  `json:"products"`
+	IncludeOptionalMetadata          bool                      `json:"include_optional_metadata"`
+	IncludePaymentInitiationMetadata bool                      `json:"include_payment_initiation_metadata"`
+	OAuth                            *bool                     `json:"oauth"`
+	RoutingNumbers                   []string                  `json:"routing_numbers"`
+	PaymentInitiation                *PaymentInitiationOptions `json:"payment_initiation,omitempty"`
+}
+
+type PaymentInitiationOptions struct {
+	PaymentID string `json:"payment_id"`
 }
 
 type GetInstitutionsResponse struct {
@@ -107,8 +129,10 @@ type getInstitutionByIDRequest struct {
 }
 
 type GetInstitutionByIDOptions struct {
-	IncludeOptionalMetadata bool `json:"include_optional_metadata"`
-	IncludeStatus           bool `json:"include_status"`
+	IncludeOptionalMetadata          bool                      `json:"include_optional_metadata"`
+	IncludePaymentInitiationMetadata bool                      `json:"include_payment_initiation_metadata"`
+	IncludeStatus                    bool                      `json:"include_status"`
+	PaymentInitiation                *PaymentInitiationOptions `json:"payment_initiation,omitempty"`
 }
 
 type GetInstitutionByIDResponse struct {
@@ -126,9 +150,11 @@ type searchInstitutionsRequest struct {
 }
 
 type SearchInstitutionsOptions struct {
-	IncludeOptionalMetadata bool                   `json:"include_optional_metadata"`
-	AccountFilter           map[string]interface{} `json:"account_filter"`
-	OAuth                   *bool                  `json:"oauth"`
+	IncludeOptionalMetadata          bool                      `json:"include_optional_metadata"`
+	IncludePaymentInitiationMetadata bool                      `json:"include_payment_initiation_metadata"`
+	AccountFilter                    map[string]interface{}    `json:"account_filter"`
+	OAuth                            *bool                     `json:"oauth"`
+	PaymentInitiation                *PaymentInitiationOptions `json:"payment_initiation,omitempty"`
 }
 
 type SearchInstitutionsResponse struct {

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -102,12 +102,11 @@ type getInstitutionsRequest struct {
 }
 
 type GetInstitutionsOptions struct {
-	Products                         []string                  `json:"products"`
-	IncludeOptionalMetadata          bool                      `json:"include_optional_metadata"`
-	IncludePaymentInitiationMetadata bool                      `json:"include_payment_initiation_metadata"`
-	OAuth                            *bool                     `json:"oauth"`
-	RoutingNumbers                   []string                  `json:"routing_numbers"`
-	PaymentInitiation                *PaymentInitiationOptions `json:"payment_initiation,omitempty"`
+	Products                         []string `json:"products"`
+	IncludeOptionalMetadata          bool     `json:"include_optional_metadata"`
+	IncludePaymentInitiationMetadata bool     `json:"include_payment_initiation_metadata"`
+	OAuth                            *bool    `json:"oauth"`
+	RoutingNumbers                   []string `json:"routing_numbers"`
 }
 
 type PaymentInitiationOptions struct {

--- a/plaid/institutions.go
+++ b/plaid/institutions.go
@@ -128,10 +128,9 @@ type getInstitutionByIDRequest struct {
 }
 
 type GetInstitutionByIDOptions struct {
-	IncludeOptionalMetadata          bool                      `json:"include_optional_metadata"`
-	IncludePaymentInitiationMetadata bool                      `json:"include_payment_initiation_metadata"`
-	IncludeStatus                    bool                      `json:"include_status"`
-	PaymentInitiation                *PaymentInitiationOptions `json:"payment_initiation,omitempty"`
+	IncludeOptionalMetadata          bool `json:"include_optional_metadata"`
+	IncludePaymentInitiationMetadata bool `json:"include_payment_initiation_metadata"`
+	IncludeStatus                    bool `json:"include_status"`
 }
 
 type GetInstitutionByIDResponse struct {


### PR DESCRIPTION
Adds payment_initiation metadata support:
- Returns some more information in the institutions endpoints response.
- Adds in an options parameter to filter institutions by payment id.