### PR TITLE
Add support for asset report create and audit copy remove endpoints

### DIFF
--- a/plaid/api_test.go
+++ b/plaid/api_test.go
@@ -16,7 +16,7 @@ var (
 	paymentInitiationMetadataSandboxInstitution      = "ins_117650"
 	paymentInitiationMetadataSandboxInstitutionQuery = "Royal Bank of Plaid"
 	balanceDatetimeInstitution                       = "ins_130016"
-	testProducts                                     = []string{"auth", "identity", "transactions"}
+	testProducts                                     = []string{"auth", "identity", "transactions", "assets"}
 )
 
 var testOptions = ClientOptions{

--- a/plaid/assets_test.go
+++ b/plaid/assets_test.go
@@ -1,0 +1,42 @@
+package plaid
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestCreateAssetReport(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+
+	// create asset report
+	createAssetReportResp, err := testClient.CreateAssetReport([]string{tokenResp.AccessToken}, 30, nil)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, createAssetReportResp.AssetReportToken)
+	assert.NotEmpty(t, createAssetReportResp.AssetReportID)
+	assert.NotEmpty(t, createAssetReportResp.RequestID)
+}
+
+func TestRemoveAuditCopy(t *testing.T) {
+	sandboxResp, _ := testClient.CreateSandboxPublicToken(sandboxInstitution, testProducts)
+	tokenResp, _ := testClient.ExchangePublicToken(sandboxResp.PublicToken)
+
+	// create asset report
+	createAssetReportResp, err := testClient.CreateAssetReport([]string{tokenResp.AccessToken}, 30, nil)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, createAssetReportResp.AssetReportToken)
+
+	// create asset report audit copy
+	createAuditCopyResp, err := testClient.CreateAuditCopy(createAssetReportResp.AssetReportToken, "ocrolus")
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, createAuditCopyResp.AuditCopyToken)
+
+	// remove asset report audit copy
+	removeAuditCopyResp, err := testClient.RemoveAuditCopy(createAuditCopyResp.AuditCopyToken)
+	assert.NoError(t, err)
+
+	assert.True(t, removeAuditCopyResp.Removed)
+}


### PR DESCRIPTION
Adding support for the `/asset_report/create` endpoint:
https://plaid.com/docs/api/products/#asset_reportcreate

And `/asset_report/audit_copy/remove` endpoint:
https://plaid.com/docs/api/products/#asset_reportaudit_copyremove

https://github.com/plaid/plaid-go/issues/85