### PR TITLE
Add helper function for easier PlaidError test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ plaidErr, err := plaid.ToPlaidError(err)
 fmt.Println(plaidErr.ErrorMessage)
 ```
 
+If you need to set up specific plaid errors to test your code, there is a helper function you can use to create a GenericOpenAPIError with embedded PlaidError:
+```go
+	plaidError := plaid.NewPlaidError(plaid.PLAIDERRORTYPE_ITEM_ERROR, "PRODUCT_NOT_READY", "", plaid.NullableString{})
+	genericOpenAPIError := plaid.MakeGenericOpenAPIError([]byte{}, "400 Bad Request", *plaidError)
+````
+
 ## Authentication
 
 First, you get your `client_id` and `secret` from your dashboard account. Authentication is handled by setting the `client_id` and `secret` on the configuration object.

--- a/plaid/client.go
+++ b/plaid/client.go
@@ -545,21 +545,31 @@ func (e GenericOpenAPIError) Model() interface{} {
 }
 
 // ToPlaidError returns a PlaidError object if the error returned
-// has the right fields. Otherwise, it returns an error
+// has the right fields. Otherwise, it returns an error.
 func ToPlaidError(err error) (PlaidError, error) {
-  genericOpenAPIError, ok := err.(GenericOpenAPIError)
-  if !ok {
-    return PlaidError{}, errors.New("PlaidError is not a GenericOpenAPIError")
-  }
+	genericOpenAPIError, ok := err.(GenericOpenAPIError)
+	if !ok {
+		return PlaidError{}, errors.New("provided error is not a PlaidOpenAPIError")
+	}
 
-  plaidError := PlaidError{}
-  if plaidError, ok = genericOpenAPIError.Model().(PlaidError); ok {
-    return plaidError, nil
-  }
+	plaidError := PlaidError{}
+	if plaidError, ok = genericOpenAPIError.Model().(PlaidError); ok {
+		return plaidError, nil
+	}
 
-  if err := json.Unmarshal(genericOpenAPIError.Body(), &plaidError); err != nil {
-    return PlaidError{}, err
-  } else {
-    return plaidError, nil
-  }
+	if err := json.Unmarshal(genericOpenAPIError.Body(), &plaidError); err != nil {
+		return PlaidError{}, err
+	} else {
+		return plaidError, nil
+	}
+}
+
+// MakeGenericOpenAPIError creates an error with an embedded plaid error for testing.
+// The needed PlaidError for testing can be provided raw as the model or in JSON format as the body.
+func MakeGenericOpenAPIError(body []byte, error string, model interface{}) GenericOpenAPIError {
+	return GenericOpenAPIError{
+		body: body,
+		error: error,
+		model: model,
+	}
 }

--- a/templates/go/client.mustache
+++ b/templates/go/client.mustache
@@ -606,21 +606,31 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 {{! Modified by Plaid - helper for Plaid's PlaidError type }}
 // ToPlaidError returns a PlaidError object if the error returned
-// has the right fields. Otherwise, it returns an error
+// has the right fields. Otherwise, it returns an error.
 func ToPlaidError(err error) (PlaidError, error) {
-  genericOpenAPIError, ok := err.(GenericOpenAPIError)
-  if !ok {
-    return PlaidError{}, errors.New("PlaidError is not a GenericOpenAPIError")
-  }
+	genericOpenAPIError, ok := err.(GenericOpenAPIError)
+	if !ok {
+		return PlaidError{}, errors.New("provided error is not a PlaidOpenAPIError")
+	}
 
-  plaidError := PlaidError{}
-  if plaidError, ok = genericOpenAPIError.Model().(PlaidError); ok {
-    return plaidError, nil
-  }
+	plaidError := PlaidError{}
+	if plaidError, ok = genericOpenAPIError.Model().(PlaidError); ok {
+		return plaidError, nil
+	}
 
-  if err := json.Unmarshal(genericOpenAPIError.Body(), &plaidError); err != nil {
-    return PlaidError{}, err
-  } else {
-    return plaidError, nil
-  }
+	if err := json.Unmarshal(genericOpenAPIError.Body(), &plaidError); err != nil {
+		return PlaidError{}, err
+	} else {
+		return plaidError, nil
+	}
+}
+
+// MakeGenericOpenAPIError creates an error with an embedded plaid error for testing.
+// PlaidError can be provided raw as the model or in JSON format as the body.
+func MakeGenericOpenAPIError(body []byte, error string, model interface{}) GenericOpenAPIError {
+	return GenericOpenAPIError{
+		body: body,
+		error: error,
+		model: model,
+	}
 }


### PR DESCRIPTION
This PR fixes #279 introducing a `PlaidGenericOpenAPIError` interface and using internally to resolve PlaidError details.  This is primarily to improve the story for testing behavior tied to a specific `PlaidError`.

Right now all of the `GenericOpenAPIError` members are internal so to setup the error needed you need to resort to reflection / unsafe eg:

```
plaidError := plaid.NewPlaidError(plaid.PLAIDERRORTYPE_ITEM_ERROR, "PRODUCT_NOT_READY", "", plaid.NullableString{})
setModel := func(f *plaid.GenericOpenAPIError, v any) {
	pointerVal := reflect.ValueOf(f)
	val := reflect.Indirect(pointerVal)
	member := val.FieldByName("model")
	ptrToY := unsafe.Pointer(member.UnsafeAddr())
	realPtrToY := (*any)(ptrToY)
	*realPtrToY = v
}
genericOpenAPIError := plaid.GenericOpenAPIError{}
setModel(&genericOpenAPIError, *plaidError)

plaidClient.EXPECT().AuthGetExecute(gomock.Any(), matchers.Predicate(func(val plaid.AuthGetRequest) bool {
	return val.AccessToken == accessToken
})).Return(plaid.AuthGetResponse{}, nil, genericOpenAPIError).Times(1)
```

With this change you can pass a plain struct defined in user code to satisfy the constraint eg:
```
type mockPlaidOpenAPIError struct {
	plaidErr plaid.PlaidError
}

func (e *mockPlaidOpenAPIError) Error() string {
	return e.plaidErr.ErrorMessage
}

func (e *mockPlaidOpenAPIError) Model() any {
	return e.plaidErr
}

func (e *mockPlaidOpenAPIError) Body() []byte {
	panic("not implemented")
}
```

And the setup snippet becomes a much simpler

```
plaidError := plaid.NewPlaidError(plaid.PLAIDERRORTYPE_ITEM_ERROR, "PRODUCT_NOT_READY", "", plaid.NullableString{})
genericOpenAPIError := &mockPlaidOpenAPIError{plaidErr: *plaidError}

plaidClient.EXPECT().AuthGetExecute(gomock.Any(), matchers.Predicate(func(val plaid.AuthGetRequest) bool {
	return val.AccessToken == accessToken
})).Return(plaid.AuthGetResponse{}, nil, genericOpenAPIError).Times(1)
```

One improvement might be to define separate interfaces for the Model / Body methods and assert one at a time.  But that seems harder to document etc.  I made the change in client.go as well just so I could test since the codegen pieces are not checked in.

We only use Auth so that is what I ran the tests for but I don't see why this would disrupt anything else 🤞 