### PR TITLE
templates/go: fix dropped error

### DIFF
--- a/templates/go/client.mustache
+++ b/templates/go/client.mustache
@@ -426,6 +426,9 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 			return
 		}
 		_, err = (*f).Write(b)
+		if err != nil {
+			return
+		}
 		_, err = (*f).Seek(0, io.SeekStart)
 		return
 	}


### PR DESCRIPTION
This fixes a dropped `err` variable in the template code that generates the `plaid` package.